### PR TITLE
feat: user and project models

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,24 @@
+class Project < ApplicationRecord
+  before_validation :generate_slug, on: :create
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true
+
+  scope :alphabetically, -> { order(name: :asc) }
+
+  def to_param = slug
+
+  private
+    def generate_slug
+      return if slug.present? || name.blank?
+
+      base = name.parameterize
+      candidate = base
+      suffix = 2
+      while Project.exists?(slug: candidate)
+        candidate = "#{base}-#{suffix}"
+        suffix += 1
+      end
+      self.slug = candidate
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+  ROLES = %w[ admin translator viewer ].freeze
+
+  normalizes :email, with: ->(email) { email.strip.downcase }
+
+  validates :email, presence: true, uniqueness: true
+  validates :role, inclusion: { in: ROLES }
+end

--- a/db/migrate/20260426052746_create_users.rb
+++ b/db/migrate/20260426052746_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.string :email, null: false
+      t.string :role, null: false, default: "translator"
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20260426052825_create_projects.rb
+++ b/db/migrate/20260426052825_create_projects.rb
@@ -1,0 +1,15 @@
+class CreateProjects < ActiveRecord::Migration[8.1]
+  def change
+    create_table :projects, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.integer :locales_count, null: false, default: 0
+      t.integer :namespaces_count, null: false, default: 0
+      t.integer :translation_keys_count, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :projects, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_052825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "projects", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "locales_count", default: 0, null: false
+    t.string "name", null: false
+    t.integer "namespaces_count", default: 0, null: false
+    t.string "slug", null: false
+    t.integer "translation_keys_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_projects_on_slug", unique: true
+  end
+
+  create_table "users", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "role", default: "translator", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,0 +1,7 @@
+main_app:
+  name: Main App
+  slug: main-app
+
+marketing_site:
+  name: Marketing Site
+  slug: marketing-site

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+admin:
+  email: admin@example.com
+  role: admin
+
+translator:
+  email: translator@example.com
+  role: translator
+
+viewer:
+  email: viewer@example.com
+  role: viewer

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class ProjectTest < ActiveSupport::TestCase
+  test "valid with name" do
+    project = Project.new(name: "New App")
+    assert project.valid?
+  end
+
+  test "requires name" do
+    project = Project.new
+    assert_not project.valid?
+    assert_includes project.errors[:name], "can't be blank"
+  end
+
+  test "auto-generates slug from name on create" do
+    project = Project.create!(name: "Cool New App")
+    assert_equal "cool-new-app", project.slug
+  end
+
+  test "appends suffix when slug already exists" do
+    Project.create!(name: "Duplicate App")
+    project = Project.create!(name: "Duplicate App")
+    assert_equal "duplicate-app-2", project.slug
+  end
+
+  test "slug is unique" do
+    duplicate = Project.new(name: "Other", slug: projects(:main_app).slug)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:slug], "has already been taken"
+  end
+
+  test "to_param returns slug" do
+    assert_equal projects(:main_app).slug, projects(:main_app).to_param
+  end
+
+  test "alphabetically scope orders by name asc" do
+    assert_equal Project.alphabetically.pluck(:name), Project.all.pluck(:name).sort
+  end
+
+  test "counter caches default to zero" do
+    project = Project.create!(name: "Counters")
+    assert_equal 0, project.locales_count
+    assert_equal 0, project.namespaces_count
+    assert_equal 0, project.translation_keys_count
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "valid with email and role" do
+    user = User.new(email: "new@example.com", role: "translator")
+    assert user.valid?
+  end
+
+  test "requires email" do
+    user = User.new(role: "translator")
+    assert_not user.valid?
+    assert_includes user.errors[:email], "can't be blank"
+  end
+
+  test "email is unique" do
+    duplicate = User.new(email: users(:admin).email, role: "translator")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:email], "has already been taken"
+  end
+
+  test "normalizes email" do
+    user = User.create!(email: "  Mixed@Example.COM  ", role: "viewer")
+    assert_equal "mixed@example.com", user.email
+  end
+
+  test "role must be admin, translator, or viewer" do
+    user = User.new(email: "x@example.com", role: "owner")
+    assert_not user.valid?
+    assert_includes user.errors[:role], "is not included in the list"
+  end
+
+  test "role defaults to translator" do
+    user = User.create!(email: "default@example.com")
+    assert_equal "translator", user.role
+  end
+end


### PR DESCRIPTION
## Summary
- Add \`User\` model with email + role enum (\`admin\`/\`translator\`/\`viewer\`), email normalization, validations
- Add \`Project\` model with auto-generated slug (with collision suffix), counter cache columns, alphabetical scope
- Both tables use UUIDv7 PKs via Postgres 18 \`uuidv7()\` default

Closes #6, #13, #5, #12

## Test plan
- [x] \`bin/rails db:migrate\` succeeds
- [x] \`bin/rails test test/models\` — 14 runs, 26 assertions, 0 failures
- [x] \`bin/rubocop\` clean on changed files
- [ ] Manually create User + Project in console after merge