### PR TITLE
docs: vendor 37signals rails compass guideline

### DIFF
--- a/compass/accessibility.md
+++ b/compass/accessibility.md
@@ -1,0 +1,73 @@
+---
+tags: [rails, 37signals, accessibility, aria, a11y]
+---
+
+# Accessibility
+
+> ARIA patterns, keyboard navigation, screen reader support, focus management.
+
+See also: [[stimulus]], [[mobile]], [[hotwire]]
+
+---
+
+## ARIA Patterns
+1. `aria-hidden="true"` on decorative elements (icons, duplicate links)
+2. `aria-label` for icon-only buttons
+3. `role="group"` with `aria-label` for related content
+4. Counts: `pluralize(count, "comment")` for screen readers
+5. `aria-label` and `aria-description` on dialogs
+6. `role="button"` for non-button interactive elements
+7. Toggle `aria-expanded` dynamically
+
+## Keyboard Navigation
+- `event.preventDefault()` on custom shortcuts
+- Reusable NavigableList controller (arrows, Enter)
+- `checkVisibility()` for visible item detection
+- Support reverse navigation (bottom-to-top trays)
+- Reset selection when dialogs open
+
+## Screen Readers
+- `.visually-hidden` / `.for-screen-reader`:
+```css
+.visually-hidden {
+  clip-path: inset(50%);
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+```
+- Prefer visually hidden text over `aria-label` for complex content
+- Fix form labels: `form.field_id(:assignee_ids, user.id)`
+- Every input needs a label
+- Semantic HTML: `<h1>`, `<nav>`, `<article>`
+
+## Focus Management
+- `:focus-visible` not `:focus`
+```css
+:is(a, button, input):where(:focus-visible) {
+  outline: var(--focus-ring-size) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+```
+- Hide focus on checkbox wrappers, show on parent: `&:has(input:focus-visible)`
+- `.hide-focus-ring` for rich text editors
+- Focus first element when dialog opens
+- `aria-selected` for custom list navigation
+
+## Platform-Specific
+- Adapt shortcuts: Cmd vs Ctrl
+- `@media (any-hover: hover)` for hover effects
+- Touch + mouse support
+
+## Quick Wins Checklist
+- [ ] `aria-hidden="true"` on decorative icons
+- [ ] `.for-screen-reader` on icon-only buttons
+- [ ] `aria-label` on dialogs
+- [ ] `pluralize()` for screen reader counts
+- [ ] `form.field_id()` for label associations
+- [ ] `:focus-visible` instead of `:focus`
+- [ ] `event.preventDefault()` on keyboard shortcuts
+- [ ] Semantic HTML
+- [ ] Keyboard-only navigation test
+- [ ] Lighthouse accessibility audit

--- a/compass/action-text.md
+++ b/compass/action-text.md
@@ -1,0 +1,47 @@
+---
+tags: [rails, 37signals, action-text, rich-text]
+---
+
+# Action Text
+
+> Sanitizer config, autolinking, link retargeting, remote images.
+
+See also: [[security]], [[views]], [[stimulus]]
+
+---
+
+## Sanitizer Config (CRITICAL for production)
+```ruby
+Rails.application.config.after_initialize do
+  ActionText::ContentHelper.allowed_tags = Rails::HTML5::SafeListSanitizer.allowed_tags
+  ActionText::ContentHelper.allowed_attributes = Rails::HTML5::SafeListSanitizer.allowed_attributes
+end
+```
+
+## Autolink at Render Time (not save time)
+Override `app/views/layouts/action_text/contents/_content.html.erb`:
+```erb
+<div class="action-text-content"><%= format_html yield -%></div>
+```
+Nokogiri traversal for URL/email autolinking, excluding `<a>`, `<pre>`, `<code>`.
+
+## Link Retargeting (Stimulus)
+```javascript
+export default class extends Controller {
+  connect() {
+    this.element.querySelectorAll("a").forEach(link => {
+      link.target = link.href.startsWith(window.location.origin) ? "_top" : "_blank"
+    })
+  }
+}
+```
+
+## Remote Images: `skip_pipeline: true`
+```erb
+<%= image_tag remote_image.url, skip_pipeline: true %>
+```
+
+## Rich Text CSS
+- `.rich-text-content p:empty { display: none; }` — hide empty paragraphs
+- Constrain media: `max-block-size: 32rem; object-fit: contain;`
+- Code blocks: `overflow-x: auto; tab-size: 2;`

--- a/compass/actioncable.md
+++ b/compass/actioncable.md
@@ -1,0 +1,65 @@
+---
+tags: [rails, 37signals, actioncable, websockets, solid-cable]
+---
+
+# ActionCable
+
+> Multi-tenant WebSockets, scoped broadcasts, Solid Cable.
+
+See also: [[multi-tenancy]], [[hotwire]], [[notifications]]
+
+---
+
+## Multi-Tenant Authentication
+- Set tenant context during connection
+- Validate session AND tenant membership
+- Reject if either fails
+
+## Account-Scoped Broadcasts (CRITICAL)
+```ruby
+# WRONG - DoS yourself across all tenants!
+<%= turbo_stream_from :all_boards %>
+# CORRECT
+<%= turbo_stream_from [ Current.account, :all_boards ] %>
+```
+
+## Dual Broadcasting
+```ruby
+broadcasts_refreshes
+broadcasts_refreshes_to ->(board) { [ board.account, :all_boards ] }
+```
+
+## Forcibly Disconnect Users
+```ruby
+ActionCable.server.remote_connections.where(current_user: self).disconnect(reconnect: false)
+```
+
+## Individual vs Batch
+Don't `update_all` when broadcasts needed — iterate with `.each`.
+
+## Solid Cable
+```yaml
+production:
+  adapter: solid_cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
+```
+
+## Use `broadcast_*_later` for async broadcasting
+
+## Selective Subscriptions
+Only subscribe to visible data:
+```erb
+<% if filter.collections.any? %>
+  <% filter.collections.each do |c| %><%= turbo_stream_from c %><% end %>
+<% else %>
+  <%= turbo_stream_from [ Current.account, :all_collections ] %>
+<% end %>
+```
+
+## Testing
+```ruby
+assert_turbo_stream_broadcasts([ notification.user, :notifications ], count: 1) do
+  notification.unread
+end
+```

--- a/compass/active-storage.md
+++ b/compass/active-storage.md
@@ -1,0 +1,46 @@
+---
+tags: [rails, 37signals, active-storage, uploads]
+---
+
+# Active Storage
+
+> Preprocessing, upload expiry, avatar optimization.
+
+See also: [[performance]], [[database]]
+
+---
+
+## Variant Preprocessing
+```ruby
+has_many_attached :embeds do |attachable|
+  attachable.variant :small, resize_to_limit: [800, 600], preprocessed: true
+end
+```
+Prevents failures on read replicas.
+
+## Direct Upload Expiry
+Extend to 48 hours for Cloudflare buffering.
+
+## Large File Preview Limits
+```ruby
+def previewable?
+  super && byte_size <= 16.megabytes
+end
+```
+
+## Avatar Optimization
+Redirect to blob URL instead of streaming through Rails.
+```ruby
+def show
+  redirect_to rails_blob_url(@user.avatar.variant(:thumb))
+end
+```
+
+## Mirror Configuration
+Write to multiple backends (local + S3), read from primary.
+```yaml
+mirror:
+  service: Mirror
+  primary: local
+  mirrors: [s3_backup]
+```

--- a/compass/ai-llm.md
+++ b/compass/ai-llm.md
@@ -1,0 +1,640 @@
+---
+tags: [compass, rails, ai, llm]
+see-also:
+  - "[[models]]"
+  - "[[controllers]]"
+  - "[[security]]"
+---
+
+# AI / LLM Integration
+
+## Command Pattern with STI (#460, #464, #466)
+
+Commands use Single Table Inheritance for a clean execute/undo pattern:
+
+### Base Command Class
+
+```ruby
+# app/models/command.rb
+class Command < ApplicationRecord
+  belongs_to :bucket
+  belongs_to :creator, class_name: "User"
+  belongs_to :commandable, polymorphic: true, optional: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :undoable, -> { where(undone_at: nil) }
+
+  def execute
+    raise NotImplementedError
+  end
+
+  def undo
+    return false unless undoable?
+    undo!
+  end
+
+  def undo!
+    raise NotImplementedError
+  end
+
+  def undoable?
+    undone_at.nil?
+  end
+
+  def needs_confirmation?
+    false
+  end
+
+  private
+
+  def mark_undone!
+    update!(undone_at: Time.current)
+  end
+end
+```
+
+### Concrete Command: Command::Assign
+
+```ruby
+# app/models/command/assign.rb
+class Command::Assign < Command
+  store_accessor :details, :assignee_id, :previous_assignee_id
+
+  validates :assignee_id, presence: true
+
+  def execute
+    card = commandable
+    self.previous_assignee_id = card.assignee_id
+    card.update!(assignee_id: assignee_id)
+    save!
+    card
+  end
+
+  def undo!
+    commandable.update!(assignee_id: previous_assignee_id)
+    mark_undone!
+  end
+
+  def summary
+    assignee = User.find(assignee_id)
+    "Assigned #{commandable.title} to #{assignee.name}"
+  end
+end
+```
+
+### Other Command Examples
+
+```ruby
+# app/models/command/close.rb
+class Command::Close < Command
+  def execute
+    commandable.close(by: creator)
+    save!
+    commandable
+  end
+
+  def undo!
+    commandable.reopen
+    mark_undone!
+  end
+end
+
+# app/models/command/move.rb
+class Command::Move < Command
+  store_accessor :details, :target_bucket_id, :source_bucket_id
+
+  def execute
+    card = commandable
+    self.source_bucket_id = card.bucket_id
+    card.update!(bucket_id: target_bucket_id)
+    save!
+    card
+  end
+
+  def undo!
+    commandable.update!(bucket_id: source_bucket_id)
+    mark_undone!
+  end
+end
+```
+
+---
+
+## Context Objects for Parsing (#460)
+
+Commands are parsed from natural language using a context object that extracts structured data:
+
+```ruby
+# app/models/command/parser/context.rb
+class Command::Parser::Context
+  attr_reader :bucket, :user, :text
+
+  def initialize(bucket:, user:, text:)
+    @bucket = bucket
+    @user = user
+    @text = text
+  end
+
+  def urls
+    @urls ||= text.scan(%r{https?://\S+}).uniq
+  end
+
+  def mentioned_cards
+    @mentioned_cards ||= urls.filter_map { |url| card_from_url(url) }
+  end
+
+  def mentioned_users
+    @mentioned_users ||= bucket.account.users.where(
+      name: text.scan(/@(\w+)/).flatten
+    )
+  end
+
+  private
+
+  def card_from_url(url)
+    path = URI.parse(url).path
+    route = Rails.application.routes.recognize_path(path)
+
+    if route[:controller] == "cards" && route[:id]
+      bucket.cards.find_by(id: route[:id])
+    end
+  rescue ActionController::RoutingError, URI::InvalidURIError
+    nil
+  end
+end
+```
+
+Usage in the parser:
+
+```ruby
+class Command::Parser
+  def parse(text)
+    context = Context.new(bucket: @bucket, user: @user, text: text)
+
+    # Pass context to LLM for command extraction
+    response = ai_client.chat(
+      messages: build_messages(context),
+      tools: available_tools
+    )
+
+    build_commands(response, context)
+  end
+end
+```
+
+---
+
+## Cost Tracking in Microcents (#978)
+
+Track AI API costs using microcents (1/10,000th of a cent) to avoid floating-point precision issues:
+
+```ruby
+# app/models/ai/usage.rb
+class Ai::Usage < ApplicationRecord
+  belongs_to :account
+
+  # Store costs in microcents: 1 cent = 10,000 microcents
+  # $0.015 per 1K tokens = 150 microcents per token
+  #
+  # Column names use _in_microcents suffix for clarity
+  # e.g., input_cost_in_microcents, output_cost_in_microcents
+
+  def total_cost_in_microcents
+    input_cost_in_microcents + output_cost_in_microcents
+  end
+
+  def total_cost_in_dollars
+    total_cost_in_microcents / 1_000_000.0
+  end
+
+  def self.total_for(account, period: 30.days)
+    where(account: account)
+      .where(created_at: period.ago..)
+      .sum(:input_cost_in_microcents) + sum(:output_cost_in_microcents)
+  end
+end
+```
+
+The `_in_` naming convention makes the unit explicit at every call site. No ambiguity about whether a value is dollars, cents, or microcents.
+
+---
+
+## Result Objects for Responses (#460, #857)
+
+LLM responses are wrapped in Struct-based result objects for pattern matching:
+
+```ruby
+# app/models/ai/result.rb
+Ai::Result = Struct.new(:commands, :response_text, :usage, keyword_init: true) do
+  def success?
+    commands.any? || response_text.present?
+  end
+
+  def has_commands?
+    commands.any?
+  end
+
+  def needs_confirmation?
+    commands.any?(&:needs_confirmation?)
+  end
+end
+```
+
+### Controller Pattern Matching
+
+```ruby
+# app/controllers/ai/chats_controller.rb
+class Ai::ChatsController < ApplicationController
+  def create
+    result = Ai::Chat.new(
+      bucket: current_bucket,
+      user: current_user
+    ).ask(params[:message])
+
+    case result
+    in { commands: [] , response_text: String => text }
+      # Pure text response - no commands extracted
+      render_response(text)
+    in { commands: [Command => cmd] } if !cmd.needs_confirmation?
+      # Single command, no confirmation needed
+      cmd.execute
+      redirect_to cmd.commandable, notice: cmd.summary
+    in { commands: _ } if result.needs_confirmation?
+      # Commands need user confirmation
+      @pending_commands = result.commands
+      render :confirm, status: :conflict
+    in { commands: [*] }
+      # Multiple commands, execute all
+      result.commands.each(&:execute)
+      redirect_to current_bucket, notice: "#{result.commands.size} actions completed"
+    end
+  end
+end
+```
+
+---
+
+## Tool Pattern for LLM Function Calling (#857)
+
+### Ai::Tool Base Class
+
+```ruby
+# app/models/ai/tool.rb
+class Ai::Tool
+  class_attribute :tool_description
+  class_attribute :tool_params, default: {}
+
+  class << self
+    def description(text)
+      self.tool_description = text
+    end
+
+    def param(name, type:, description:, required: true, enum: nil)
+      self.tool_params = tool_params.merge(
+        name => { type: type, description: description, required: required, enum: enum }
+      )
+    end
+
+    def tool_name
+      name.demodulize.underscore
+    end
+
+    def schema
+      {
+        type: "function",
+        function: {
+          name: tool_name,
+          description: tool_description,
+          parameters: {
+            type: "object",
+            properties: tool_params.transform_values { |v|
+              v.slice(:type, :description, :enum).compact
+            },
+            required: tool_params.select { |_, v| v[:required] }.keys.map(&:to_s)
+          }
+        }
+      }
+    end
+  end
+
+  attr_reader :bucket, :user, :arguments
+
+  def initialize(bucket:, user:, arguments: {})
+    @bucket = bucket
+    @user = user
+    @arguments = arguments.symbolize_keys
+  end
+
+  def call
+    raise NotImplementedError
+  end
+
+  private
+
+  def paginated_response(scope, page: 1, per: 20)
+    records = scope.page(page).per(per)
+
+    {
+      results: records.map { |r| serialize(r) },
+      total: records.total_count,
+      page: records.current_page,
+      total_pages: records.total_pages
+    }
+  end
+
+  def serialize(record)
+    record.as_json
+  end
+end
+```
+
+### Ai::ListCardsTool with DSL
+
+```ruby
+# app/models/ai/list_cards_tool.rb
+class Ai::ListCardsTool < Ai::Tool
+  include Ai::Tool::Filter
+
+  description "Search and list cards in the current project. Returns paginated results."
+
+  param :query,    type: "string",  description: "Search query to filter cards by title or body", required: false
+  param :status,   type: "string",  description: "Filter by status", required: false, enum: %w[open closed archived]
+  param :assignee, type: "string",  description: "Filter by assignee name", required: false
+  param :tag,      type: "string",  description: "Filter by tag", required: false
+  param :sort,     type: "string",  description: "Sort order", required: false, enum: %w[newest oldest updated due]
+  param :page,     type: "integer", description: "Page number (default 1)", required: false
+
+  register_filters :status, :assignee, :tag, :query
+
+  def call
+    scope = bucket.cards.visible_to(user)
+    scope = apply_filters(scope)
+    scope = apply_sort(scope)
+
+    paginated_response(scope, page: arguments.fetch(:page, 1))
+  end
+
+  private
+
+  def apply_sort(scope)
+    case arguments[:sort]
+    when "newest"  then scope.order(created_at: :desc)
+    when "oldest"  then scope.order(created_at: :asc)
+    when "updated" then scope.order(updated_at: :desc)
+    when "due"     then scope.order(due_on: :asc)
+    else scope.order(position: :asc)
+    end
+  end
+
+  def serialize(card)
+    {
+      id: card.id,
+      title: card.title,
+      status: card.status,
+      assignee: card.assignee&.name,
+      due_on: card.due_on,
+      tags: card.tags
+    }
+  end
+end
+```
+
+Note the user-scoping: `bucket.cards.visible_to(user)` ensures the LLM can never access cards the user cannot see.
+
+---
+
+## Confirmation Pattern for Bulk Operations (#464)
+
+### HTTP 409 Conflict for Confirmation
+
+```ruby
+# app/controllers/ai/chats_controller.rb
+class Ai::ChatsController < ApplicationController
+  def create
+    result = process_message(params[:message])
+
+    if result.needs_confirmation?
+      @pending_commands = result.commands
+      @confirmation_token = sign_commands(result.commands)
+
+      render :confirm, status: :conflict # 409
+      return
+    end
+
+    execute_commands(result.commands)
+  end
+
+  def confirm
+    commands = verify_commands(params[:confirmation_token])
+
+    commands.each(&:execute)
+    redirect_to current_bucket, notice: "#{commands.size} actions completed"
+  end
+
+  private
+
+  def sign_commands(commands)
+    Rails.application.message_verifier(:ai_commands).generate(
+      commands.map(&:attributes),
+      expires_in: 5.minutes
+    )
+  end
+
+  def verify_commands(token)
+    attrs_list = Rails.application.message_verifier(:ai_commands).verify(token)
+    attrs_list.map { |attrs| Command.new(attrs) }
+  end
+end
+```
+
+### Command::Cards with needs_confirmation?
+
+```ruby
+# app/models/command/cards.rb
+class Command::Cards < Command
+  store_accessor :details, :card_ids, :action
+
+  def needs_confirmation?
+    card_ids.size > 1  # Bulk operations always need confirmation
+  end
+
+  def execute
+    cards.each { |card| apply_action(card) }
+    save!
+  end
+
+  def summary
+    "#{action.titleize} #{card_ids.size} cards"
+  end
+
+  private
+
+  def cards
+    bucket.cards.where(id: card_ids)
+  end
+
+  def apply_action(card)
+    case action
+    when "close"  then card.close(by: creator)
+    when "assign" then card.update!(assignee_id: details["assignee_id"])
+    when "move"   then card.update!(bucket_id: details["target_bucket_id"])
+    end
+  end
+end
+```
+
+---
+
+## Filter Registry Pattern (#857)
+
+Reusable filter application for AI tools:
+
+```ruby
+# app/models/ai/tool/filter.rb
+module Ai::Tool::Filter
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def register_filters(*filter_names)
+      self.registered_filters = filter_names
+    end
+
+    def registered_filters
+      @registered_filters || []
+    end
+
+    def registered_filters=(filters)
+      @registered_filters = filters
+    end
+  end
+
+  def apply_filters(scope)
+    self.class.registered_filters.each do |filter_name|
+      scope = filter(scope, filter_name)
+    end
+    scope
+  end
+
+  def filter(scope, name)
+    value = arguments[name]
+    return scope if value.blank?
+
+    case name
+    when :status
+      scope.where(status: value)
+    when :assignee
+      user = bucket.account.users.find_by("name ILIKE ?", "%#{value}%")
+      user ? scope.where(assignee: user) : scope.none
+    when :tag
+      scope.tagged_with(value)
+    when :query
+      scope.search(value)
+    else
+      scope
+    end
+  end
+end
+```
+
+Tools declare their filters with `register_filters` and get `apply_filters` for free:
+
+```ruby
+class Ai::ListCardsTool < Ai::Tool
+  include Ai::Tool::Filter
+
+  register_filters :status, :assignee, :tag, :query
+
+  def call
+    scope = bucket.cards.visible_to(user)
+    scope = apply_filters(scope)
+    paginated_response(scope)
+  end
+end
+```
+
+---
+
+## Order Clause Parser (#857)
+
+Safely parse user-provided sort instructions into SQL order clauses:
+
+```ruby
+# app/models/ai/order_clause_parser.rb
+class Ai::OrderClauseParser
+  ALLOWED_DIRECTIONS = %w[asc desc].freeze
+
+  PERMITTED_COLUMNS = {
+    "cards" => %w[created_at updated_at position due_on title status],
+    "comments" => %w[created_at updated_at],
+    "users" => %w[name created_at]
+  }.freeze
+
+  def initialize(table:)
+    @table = table
+  end
+
+  def parse(sort_string)
+    return default_order if sort_string.blank?
+
+    clauses = sort_string.split(",").map(&:strip)
+    clauses.filter_map { |clause| parse_clause(clause) }
+           .presence || default_order
+  end
+
+  private
+
+  def parse_clause(clause)
+    parts = clause.downcase.split(/\s+/)
+    column = parts[0]
+    direction = parts[1] || "asc"
+
+    return nil unless permitted_column?(column)
+    return nil unless ALLOWED_DIRECTIONS.include?(direction)
+
+    # Return Arel node - never interpolate into SQL strings
+    Arel.sql("#{@table}.#{column} #{direction}")
+  end
+
+  def permitted_column?(column)
+    permitted = PERMITTED_COLUMNS[@table] || []
+    permitted.include?(column)
+  end
+
+  def default_order
+    [Arel.sql("#{@table}.created_at desc")]
+  end
+end
+```
+
+### SQL Injection Prevention
+
+The parser prevents SQL injection by:
+1. Whitelisting columns per table in `PERMITTED_COLUMNS`
+2. Whitelisting directions to only `asc`/`desc`
+3. Rejecting any clause that doesn't match known columns
+4. Never interpolating user input directly into SQL
+
+```ruby
+# Usage in a tool
+class Ai::ListCardsTool < Ai::Tool
+  def apply_sort(scope)
+    parser = Ai::OrderClauseParser.new(table: "cards")
+    order_clauses = parser.parse(arguments[:sort])
+    scope.order(order_clauses)
+  end
+end
+```
+
+---
+
+## Code Review Culture
+
+Four observations from reviewing AI-related PRs in the codebase:
+
+1. **Security is non-negotiable** - Every AI tool that touches data scopes through `visible_to(user)`. The LLM never gets unscoped access. Review comments consistently flag missing user-scoping.
+
+2. **Cost awareness is built in** - Microcent tracking is added from day one, not bolted on later. Every API call records its cost. This enables per-account usage limits.
+
+3. **Undo is a first-class concern** - Commands store enough state to reverse themselves. The `undo!` method is not optional - if a command cannot be undone, it must override `undoable?` to return `false`.
+
+4. **Confirmation before bulk changes** - The 409 Conflict pattern ensures the LLM cannot silently modify many records. The user always sees what will happen before it happens. Signed tokens prevent tampering with the pending command list.

--- a/compass/authentication.md
+++ b/compass/authentication.md
@@ -1,0 +1,401 @@
+---
+tags: [compass, rails, authentication, security]
+---
+
+# Authentication
+
+See also: [[security]], [[controllers]], [[multi-tenancy]]
+
+## Why Not Devise
+
+37signals rolls custom authentication rather than using Devise. The entire authentication system is roughly 150 lines of code spread across a concern, a couple of models, and a controller. Why?
+
+- Devise is a complex abstraction over something Rails already makes easy
+- Password-based auth is being replaced by magic links and passkeys
+- Custom auth is easier to understand, debug, and modify
+- You own every line — no black-box middleware or callbacks
+- It fits naturally into the Rails conventions you already know
+
+When your auth is ~150 lines of code you wrote, there's nothing to "configure" — you just read it.
+
+## Magic Link Flow
+
+Instead of passwords, authentication uses a 6-digit magic link code sent via email:
+
+1. User enters their email address on the sign-in form
+2. System finds the `Identity` by email
+3. A `MagicLink` record is created with a generated 6-digit code
+4. The code is emailed to the user (code appears in the subject line for convenience)
+5. User enters the 6-digit code on the verification form
+6. System finds the magic link, consumes it (marks as used), and creates a `Session`
+7. Session token is stored in a cookie scoped to the account path
+
+```
+User enters email
+    → Identity lookup
+    → MagicLink.create!(code: Code.generate)
+    → MagicLinkMailer delivers code
+    → User enters 6-digit code
+    → MagicLink found & consumed
+    → Session created
+    → Cookie set
+    → Redirect to app
+```
+
+## Identity Model
+
+Identity is deliberately separated from User. A User belongs to an Account and represents membership. An Identity represents a person's authentication credentials across all accounts.
+
+```ruby
+# app/models/identity.rb
+class Identity < ApplicationRecord
+  has_many :users
+  has_many :sessions, dependent: :destroy
+  has_many :magic_links, dependent: :destroy
+  has_many :access_tokens, dependent: :destroy
+
+  has_many :accounts, through: :users
+
+  normalizes :email, with: ->(email) { email.strip.downcase }
+
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  def authenticate_with(code)
+    magic_links.unclaimed.find_by(code: MagicLink::Code.sanitize(code))&.consume!
+  end
+end
+```
+
+Key insight: one Identity can have many Users across many Accounts. This is how multi-account support works — the person (Identity) is distinct from their membership (User) in any given Account.
+
+## MagicLink Model
+
+```ruby
+# app/models/magic_link.rb
+class MagicLink < ApplicationRecord
+  CODE_LENGTH = 6
+  EXPIRATION_TIME = 15.minutes
+
+  belongs_to :identity
+
+  scope :unclaimed, -> { where(claimed_at: nil).where("created_at >= ?", EXPIRATION_TIME.ago) }
+
+  before_create { self.code = Code.generate }
+
+  def consume!
+    update!(claimed_at: Time.current)
+  end
+
+  def expired?
+    created_at < EXPIRATION_TIME.ago
+  end
+
+  module Code
+    def self.generate
+      SecureRandom.random_number(10**MagicLink::CODE_LENGTH).to_s.rjust(MagicLink::CODE_LENGTH, "0")
+    end
+
+    def self.sanitize(code)
+      code.to_s.strip.gsub(/[^0-9]/, "").first(MagicLink::CODE_LENGTH)
+    end
+  end
+end
+```
+
+The `Code` module handles generation (zero-padded random 6-digit number) and sanitization (strip whitespace, remove non-digits, truncate). The `consume!` pattern marks the link as used by setting `claimed_at`, and the `unclaimed` scope ensures codes can only be used once and only within the expiration window.
+
+## Session Model
+
+```ruby
+# app/models/session.rb
+class Session < ApplicationRecord
+  belongs_to :identity
+
+  has_secure_token
+
+  before_create { self.ip_address = Current.ip_address }
+  before_create { self.user_agent = Current.user_agent }
+end
+```
+
+Sessions are simple token holders. The token is stored in the cookie and used to look up the session on each request. IP address and user agent are recorded for audit purposes.
+
+## Authentication Concern
+
+This is the core of the system — a controller concern that provides a class-level DSL for declaring authentication rules and instance methods for session management.
+
+```ruby
+# app/controllers/concerns/authentication.rb
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :resume_session
+    helper_method :signed_in?
+  end
+
+  class_methods do
+    # Skip authentication entirely — for sign-in pages, public pages
+    def allow_unauthenticated_access(**options)
+      skip_before_action :resume_session, **options
+    end
+
+    # Redirect away if already signed in — for sign-in/sign-up pages
+    def require_unauthenticated_access(**options)
+      allow_unauthenticated_access(**options)
+      before_action :redirect_signed_in_user, **options
+    end
+
+    # Skip account scoping — for account selection, global pages
+    def disallow_account_scope(**options)
+      before_action :ensure_no_account_scope, **options
+    end
+  end
+
+  private
+
+    def resume_session
+      if session_token = cookies.signed[:session_token]
+        if session = Session.find_by(token: session_token)
+          set_current_session(session)
+        end
+      end
+
+      request_authentication unless signed_in?
+    end
+
+    def authenticate_by_bearer_token
+      if token = request.headers["Authorization"]&.delete_prefix("Bearer ")
+        if access_token = AccessToken.find_by(token: token)
+          set_current_session(access_token.session)
+        end
+      end
+    end
+
+    def request_authentication
+      session[:return_to_url] = request.url
+      redirect_to new_session_url
+    end
+
+    def signed_in?
+      Current.session.present?
+    end
+
+    def redirect_signed_in_user
+      redirect_to root_url if signed_in?
+    end
+
+    def start_new_session_for(identity, account: nil)
+      session = identity.sessions.create!
+      set_current_session(session)
+
+      cookies.signed.permanent[:session_token] = {
+        value: session.token,
+        httponly: true,
+        same_site: :lax,
+        path: account ? "/#{account.id}" : "/"
+      }
+    end
+
+    def set_current_session(session)
+      Current.session = session
+      Current.identity = session.identity
+    end
+
+    def terminate_session
+      Current.session&.destroy
+      cookies.delete(:session_token)
+      redirect_to new_session_url
+    end
+
+    def ensure_no_account_scope
+      # Override in account-scoped controllers
+    end
+end
+```
+
+The class-level DSL is the key design:
+- `allow_unauthenticated_access` — skips the `resume_session` before_action entirely
+- `require_unauthenticated_access` — also redirects already-signed-in users away
+- `disallow_account_scope` — for controllers that operate outside an account context
+
+## Sessions Controller
+
+```ruby
+# app/controllers/sessions_controller.rb
+class SessionsController < ApplicationController
+  disallow_account_scope
+  require_unauthenticated_access
+
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> {
+    flash[:alert] = "Try again later."
+    redirect_to new_session_url
+  }
+
+  def new
+  end
+
+  def create
+    if identity = Identity.find_by(email: params[:email])
+      magic_link = identity.magic_links.create!
+      MagicLinkMailer.with(identity: identity, magic_link: magic_link).sign_in.deliver_later
+
+      redirect_to new_magic_link_url(email: params[:email])
+    else
+      redirect_to new_session_url, alert: "No account found with that email."
+    end
+  end
+
+  def destroy
+    terminate_session
+  end
+end
+```
+
+Note the stacking of `disallow_account_scope` and `require_unauthenticated_access` — these are controller-level declarations that read like a spec of the controller's auth requirements. The `rate_limit` is built into Rails 7.2+ and protects against brute-force email enumeration.
+
+## Magic Link Controller
+
+```ruby
+# app/controllers/magic_links_controller.rb
+class MagicLinksController < ApplicationController
+  disallow_account_scope
+  require_unauthenticated_access
+
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> {
+    flash[:alert] = "Try again later."
+    redirect_to new_session_url
+  }
+
+  def new
+    @email = params[:email]
+  end
+
+  def create
+    identity = Identity.find_by!(email: params[:email])
+
+    if magic_link = identity.authenticate_with(params[:code])
+      start_new_session_for(identity)
+      redirect_to after_sign_in_url
+    else
+      redirect_to new_magic_link_url(email: params[:email]), alert: "Invalid or expired code."
+    end
+  end
+
+  private
+
+    def after_sign_in_url
+      session.delete(:return_to_url) || root_url
+    end
+end
+```
+
+The controller verifies the email matches (looks up identity by email first), then delegates to `identity.authenticate_with(code)` which handles the sanitization and consumption of the magic link. The `after_sign_in_url` pattern restores the user to where they were trying to go before being redirected to sign in.
+
+## Magic Link Mailer
+
+```ruby
+# app/mailers/magic_link_mailer.rb
+class MagicLinkMailer < ApplicationMailer
+  def sign_in
+    @identity = params[:identity]
+    @magic_link = params[:magic_link]
+
+    mail(
+      to: @identity.email,
+      subject: "Your sign-in code is #{@magic_link.code}"
+    )
+  end
+end
+```
+
+The code appears directly in the subject line. This is intentional — most people will see it in their notification/preview without even opening the email. The email body can contain additional context, but the subject line is the primary delivery mechanism.
+
+## Current Context
+
+```ruby
+# app/models/current.rb
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  attribute :identity
+  attribute :user
+  attribute :account
+
+  attribute :ip_address
+  attribute :user_agent
+
+  def user
+    identity&.users&.find_by(account: account) if account
+  end
+end
+```
+
+`Current` is the thread-safe global context for the request. It holds the session, identity, and derived user/account. The `user` method dynamically resolves based on the current account context.
+
+## Multi-Account Support
+
+One person (Identity) can belong to many accounts through User records:
+
+```ruby
+# An identity can have many users across accounts
+identity.users          # => [User(account: basecamp), User(account: hey)]
+identity.accounts       # => [Account(basecamp), Account(hey)]
+
+# In a request context, Current resolves the right user
+Current.identity = identity
+Current.account = account
+Current.user            # => the User for this identity + account combo
+```
+
+The Identity-User separation makes multi-account support natural. There is no "current user" problem — there's a current identity and a current account, and the user is derived.
+
+## Session Path Scoping
+
+Session cookies are scoped to the account path to prevent cross-account session leakage:
+
+```ruby
+# In start_new_session_for
+cookies.signed.permanent[:session_token] = {
+  value: session.token,
+  httponly: true,
+  same_site: :lax,
+  path: account ? "/#{account.id}" : "/"
+}
+```
+
+When a user signs into Account A, the cookie is set with `path: "/123"`. This means the browser only sends that cookie for requests under `/123/...`. Signing into Account B gets a separate cookie at `/456/...`. This avoids accidental cross-account access and allows simultaneous sessions in different accounts.
+
+## Development Convenience
+
+In development, the magic link code is flashed directly so you don't have to check email:
+
+```ruby
+# In SessionsController#create (development only)
+if identity = Identity.find_by(email: params[:email])
+  magic_link = identity.magic_links.create!
+  MagicLinkMailer.with(identity: identity, magic_link: magic_link).sign_in.deliver_later
+
+  # Show code in flash during development for convenience
+  if Rails.env.local?
+    flash[:magic_link_code] = magic_link.code
+  end
+
+  redirect_to new_magic_link_url(email: params[:email])
+end
+```
+
+The safety net: this uses `Rails.env.local?` which returns true for both `development` and `test`, but never `production`. Even if this code accidentally shipped, the flash value wouldn't be displayed in production views (assuming you don't render `flash[:magic_link_code]` in production layouts).
+
+## Key Principles
+
+1. **Own your auth code.** ~150 lines is not worth a gem dependency. You'll understand every line, and you'll never fight a gem's assumptions about your data model.
+
+2. **Separate identity from membership.** Identity = the person. User = their role in an account. This separation makes multi-account support trivial and avoids the "current_user belongs to one account" trap.
+
+3. **Use magic links over passwords.** Passwords create support burden (resets, complexity rules, breaches). A 6-digit code sent to a verified email is simpler for users and developers.
+
+4. **Make the auth DSL declarative.** Controllers should declare their auth requirements at the class level (`require_unauthenticated_access`, `allow_unauthenticated_access`) not bury auth logic in before_actions.
+
+5. **Scope sessions to accounts.** Cookie path scoping prevents cross-account session leakage without complex token management.
+
+6. **Rate limit authentication endpoints.** Use Rails' built-in `rate_limit` to protect sign-in and code verification endpoints from brute force attacks.

--- a/compass/background-jobs.md
+++ b/compass/background-jobs.md
@@ -1,0 +1,80 @@
+---
+tags: [rails, 37signals, background-jobs, solid-queue]
+---
+
+# Background Jobs
+
+> Solid Queue. Shallow jobs. Transaction safety.
+
+See also: [[database]], [[email]], [[webhooks]]
+
+---
+
+## Configuration
+- Dev: `SOLID_QUEUE_IN_PUMA=1` (no separate process)
+- Prod: workers = CPU cores, 3 threads for I/O
+- Stagger recurring jobs to prevent spikes
+
+## Transaction Safety
+```ruby
+ActiveJob::Base.enqueue_after_transaction_commit = true
+```
+Prevents jobs from running before data exists.
+
+## Error Handling
+
+### Transient — retry with backoff
+```ruby
+retry_on Net::OpenTimeout, Net::ReadTimeout, wait: :polynomially_longer
+retry_on Net::SMTPServerBusy, wait: :polynomially_longer
+```
+
+### Permanent — swallow, log at info
+```ruby
+rescue_from Net::SMTPFatalError do |error|
+  case error.message
+  when /\A550 5\.1\.1/, /\A552 5\.6\.0/
+    Sentry.capture_exception error, level: :info
+  else
+    raise
+  end
+end
+```
+
+## Shallow Jobs
+```ruby
+class NotifyRecipientsJob < ApplicationJob
+  def perform(notifiable)
+    notifiable.notify_recipients
+  end
+end
+```
+
+## `_later` / `_now` Convention
+```ruby
+def notify_recipients       # sync - actual work
+  Notifier.for(self)&.notify
+end
+private
+  def notify_recipients_later # async - enqueue
+    NotifyRecipientsJob.perform_later(self)
+  end
+```
+
+## Continuable Jobs
+```ruby
+include ActiveJob::Continuable
+def perform(event)
+  step :dispatch do |step|
+    Webhook.active.find_each(start: step.cursor) do |webhook|
+      webhook.trigger(event)
+      step.advance! from: webhook.id
+    end
+  end
+end
+```
+Resumes from where it left off after crashes.
+
+## Maintenance
+- Clean finished jobs (hourly): `SolidQueue::Job.clear_finished_in_batches`
+- Clean orphaned data: unused tags, old webhook deliveries, expired magic links

--- a/compass/caching.md
+++ b/compass/caching.md
@@ -1,0 +1,385 @@
+---
+tags: [compass, rails, caching, performance]
+---
+
+# Caching
+
+See also: [[views]], [[performance]], [[controllers]]
+
+## HTTP Caching (ETags)
+
+HTTP caching lets the browser skip downloading a response it already has. Rails makes this easy with `fresh_when`.
+
+### How ETags Work
+
+```
+1. Browser requests GET /projects/1
+2. Server renders response, computes ETag from content hash
+3. Server sends response with header: ETag: "abc123"
+4. Browser caches response locally
+
+5. Browser requests GET /projects/1 again
+6. Browser sends header: If-None-Match: "abc123"
+7. Server computes ETag, sees it matches
+8. Server sends 304 Not Modified (empty body)
+9. Browser uses cached version
+```
+
+The server still runs the controller action and computes the ETag, but skips rendering the view and sending the body. This saves rendering time and bandwidth.
+
+### fresh_when with Arrays
+
+Pass an array to `fresh_when` to build a composite ETag from multiple objects:
+
+```ruby
+class ProjectsController < ApplicationController
+  def show
+    @project = Current.account.projects.find(params[:id])
+    @tasks = @project.tasks.order(:position)
+
+    fresh_when [@project, @tasks]
+  end
+end
+```
+
+Rails calls `cache_key_with_version` on each element. If any object changes (updated_at changes), the ETag changes, and the browser gets a fresh response.
+
+For collections, ActiveRecord computes a single cache key from the count and maximum `updated_at`:
+
+```ruby
+# @tasks.cache_key_with_version
+# => "tasks/query-3-20240115120000000000"
+#    (3 records, max updated_at)
+```
+
+### Don't HTTP Cache Forms
+
+Never use `fresh_when` on actions that render forms. Rails CSRF tokens are embedded in forms, and a 304 response means the browser reuses a stale CSRF token, resulting in a 422 Unprocessable Entity on form submission.
+
+```ruby
+# BAD — will cause 422 errors on form submit
+class ProjectsController < ApplicationController
+  def edit
+    @project = Current.account.projects.find(params[:id])
+    fresh_when @project  # Don't do this!
+  end
+end
+
+# GOOD — only use fresh_when on read-only actions
+class ProjectsController < ApplicationController
+  def show
+    @project = Current.account.projects.find(params[:id])
+    fresh_when @project
+  end
+
+  def edit
+    @project = Current.account.projects.find(params[:id])
+    # No fresh_when here
+  end
+end
+```
+
+### Public Caching
+
+For content that's the same for all users (marketing pages, public API responses), use `expires_in` with `public: true`:
+
+```ruby
+class HomePagesController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    expires_in 30.seconds, public: true
+  end
+end
+```
+
+This sets `Cache-Control: public, max-age=30`. CDNs and proxies can cache this response and serve it directly without hitting your server at all. Keep the duration short (30 seconds is a good default) so updates propagate quickly.
+
+## Fragment Caching
+
+Fragment caching stores rendered HTML fragments and reuses them when the underlying data hasn't changed.
+
+### Bad vs Good: Include Context
+
+```ruby
+# BAD — cache key doesn't reflect all inputs
+<% cache project do %>
+  <div class="project">
+    <h2><%= project.name %></h2>
+    <p><%= project.tasks.count %> tasks</p>
+    <% if Current.user.admin? %>
+      <%= link_to "Edit", edit_project_path(project) %>
+    <% end %>
+  </div>
+<% end %>
+```
+
+This is broken: the admin link will be cached for the first user who views it, then shown (or hidden) for everyone. The cache key is just the project's cache_key_with_version — it doesn't account for the user's role.
+
+```ruby
+# GOOD — cache key includes everything that affects output
+<% cache [project, Current.user.admin?] do %>
+  <div class="project">
+    <h2><%= project.name %></h2>
+    <p><%= project.tasks.count %> tasks</p>
+    <% if Current.user.admin? %>
+      <%= link_to "Edit", edit_project_path(project) %>
+    <% end %>
+  </div>
+<% end %>
+```
+
+The cache key now includes the admin boolean, so admins and non-admins get separate cached fragments.
+
+### Include What Affects Output
+
+The cache key must include everything that changes the rendered HTML:
+
+```ruby
+# Object being rendered
+<% cache project do %>
+
+# Object + related data that appears in the fragment
+<% cache [project, project.tasks] do %>
+
+# Object + user-specific rendering
+<% cache [project, Current.user.admin?] do %>
+
+# Object + locale
+<% cache [project, I18n.locale] do %>
+
+# Multiple varying inputs
+<% cache [project, project.tasks, Current.user.admin?, I18n.locale] do %>
+```
+
+### Touch Chains
+
+When a child record changes, the parent's cache must be invalidated. Use `touch: true` on belongs_to associations to propagate changes up the chain (#566):
+
+```ruby
+class Task < ApplicationRecord
+  belongs_to :project, touch: true
+end
+
+class Comment < ApplicationRecord
+  belongs_to :task, touch: true
+end
+```
+
+Now when a comment is created or updated:
+1. `comment.save!` triggers `task.touch` (updates task's `updated_at`)
+2. `task.touch` triggers `project.touch` (updates project's `updated_at`)
+3. Any fragment cached on `project` is automatically invalidated
+
+This creates a chain: Comment → Task → Project. The project's `cache_key_with_version` changes, so `<% cache project do %>` produces a cache miss and re-renders.
+
+Be deliberate about touch chains. Don't add `touch: true` everywhere — only where a child change should invalidate the parent's cached representation.
+
+### Domain Models for Cache Keys
+
+Sometimes you need a cache key that represents a concept, not a single record. Create a domain model for it (#1132):
+
+```ruby
+# app/models/project/cache_key.rb
+class Project::CacheKey
+  attr_reader :project
+
+  def initialize(project)
+    @project = project
+  end
+
+  def cache_key_with_version
+    "project_summary/#{project.id}-#{project.updated_at.to_i}-#{tasks_key}-#{members_key}"
+  end
+
+  private
+
+  def tasks_key
+    project.tasks.maximum(:updated_at).to_i
+  end
+
+  def members_key
+    project.members.maximum(:updated_at).to_i
+  end
+end
+```
+
+```ruby
+<% cache Project::CacheKey.new(@project) do %>
+  <!-- complex rendering that depends on project, tasks, and members -->
+<% end %>
+```
+
+This gives you explicit control over what invalidates the cache, without relying on touch chains for everything.
+
+## Lazy-Loaded Content with Turbo Frames
+
+For content that is expensive to render or rarely seen, load it lazily with Turbo Frames (#1089).
+
+### Menu Example with Dialog
+
+A navigation menu that loads its content only when the user hovers over it:
+
+```erb
+<!-- In the navigation bar -->
+<details data-controller="lazy-menu" data-action="mouseenter->lazy-menu#load">
+  <summary>Projects</summary>
+  <turbo-frame id="projects_menu" src="" loading="lazy">
+    <!-- Skeleton placeholder shown while loading -->
+    <div class="menu-skeleton">
+      <div class="skeleton-item"></div>
+      <div class="skeleton-item"></div>
+      <div class="skeleton-item"></div>
+    </div>
+  </turbo-frame>
+</details>
+```
+
+```javascript
+// app/javascript/controllers/lazy_menu_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  load() {
+    const frame = this.element.querySelector("turbo-frame")
+    if (!frame.src || frame.src === "") {
+      frame.src = this.element.dataset.menuUrl
+    }
+  }
+}
+```
+
+The Turbo Frame has no `src` initially. On `mouseenter`, the Stimulus controller sets the `src`, triggering a fetch. The skeleton placeholder gives visual feedback while loading.
+
+### Controller with fresh_when
+
+The endpoint that serves the lazy-loaded content can use HTTP caching:
+
+```ruby
+class Menus::ProjectsController < ApplicationController
+  def show
+    @projects = Current.account.projects.order(:name)
+    fresh_when @projects
+  end
+end
+```
+
+```erb
+<!-- app/views/menus/projects/show.html.erb -->
+<turbo-frame id="projects_menu">
+  <ul class="menu">
+    <% @projects.each do |project| %>
+      <li><%= link_to project.name, project_path(project) %></li>
+    <% end %>
+  </ul>
+</turbo-frame>
+```
+
+The first hover fetches and renders the menu. Subsequent hovers get a 304 Not Modified if the project list hasn't changed.
+
+## User-Specific Content in Cached Fragments
+
+When a fragment is mostly the same for everyone but has small user-specific elements (like "Edit" buttons visible only to the owner), avoid splitting the cache by user. Instead, cache one version and use JavaScript to show/hide user-specific elements.
+
+### Data Attributes with Stimulus
+
+```erb
+<% cache project do %>
+  <div class="project"
+       data-controller="ownership"
+       data-ownership-owner-id-value="<%= project.creator_id %>">
+    <h2><%= project.name %></h2>
+    <p><%= project.description %></p>
+
+    <div data-ownership-target="ownerOnly" class="hidden">
+      <%= link_to "Edit", edit_project_path(project) %>
+      <%= button_to "Delete", project_path(project), method: :delete %>
+    </div>
+  </div>
+<% end %>
+```
+
+```javascript
+// app/javascript/controllers/ownership_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["ownerOnly"]
+  static values = { ownerId: Number }
+
+  connect() {
+    if (this.isOwner) {
+      this.ownerOnlyTargets.forEach(el => el.classList.remove("hidden"))
+    }
+  }
+
+  get isOwner() {
+    return this.ownerIdValue === window.currentUserId
+  }
+}
+```
+
+The cached fragment includes the owner-only elements but hides them with CSS. The Stimulus controller reveals them client-side if the current user matches. This way the fragment is cached once for all users, and authorization is still enforced server-side on the actual edit/delete endpoints.
+
+### JS Show/Hide Pattern
+
+The general pattern:
+1. Render all possible UI elements in the cached fragment
+2. Hide user-specific elements with `class="hidden"`
+3. Add data attributes with the relevant IDs/roles
+4. Use a Stimulus controller to show/hide based on the current user
+5. Always enforce authorization server-side on mutations
+
+This is not a security mechanism — it's a caching optimization. The server must still check permissions on every write action.
+
+## Extract Dynamic Content to Turbo Frames
+
+When a mostly-static page has one dynamic section, extract the dynamic part into a Turbo Frame so the rest can be cached (#317).
+
+### Assignment Dropdown Extraction
+
+A project page where everything is cacheable except the "Assign to" dropdown (which shows different users based on permissions):
+
+```erb
+<!-- app/views/projects/show.html.erb -->
+<% cache @project do %>
+  <div class="project">
+    <h1><%= @project.name %></h1>
+    <p><%= @project.description %></p>
+
+    <!-- Everything above is cacheable -->
+
+    <!-- This part varies by user, so extract it -->
+    <turbo-frame id="assignment_dropdown" src="<%= project_assignments_path(@project) %>">
+      <span class="loading">Loading assignments...</span>
+    </turbo-frame>
+
+    <!-- Continue with cacheable content -->
+    <div class="project-details">
+      <%= render @project.tasks %>
+    </div>
+  </div>
+<% end %>
+```
+
+```ruby
+class Projects::AssignmentsController < ApplicationController
+  def index
+    @project = Current.account.projects.find(params[:project_id])
+    @assignable_users = @project.assignable_users_for(Current.user)
+  end
+end
+```
+
+```erb
+<!-- app/views/projects/assignments/index.html.erb -->
+<turbo-frame id="assignment_dropdown">
+  <select name="assigned_to">
+    <% @assignable_users.each do |user| %>
+      <option value="<%= user.id %>"><%= user.name %></option>
+    <% end %>
+  </select>
+</turbo-frame>
+```
+
+The main project page is cached for everyone. The assignment dropdown is loaded separately per-user via a Turbo Frame. This gives you the caching benefit for 95% of the page while still personalizing the dynamic 5%.

--- a/compass/configuration.md
+++ b/compass/configuration.md
@@ -1,0 +1,378 @@
+---
+tags: [compass, rails, configuration, kamal, deployment]
+---
+
+# Configuration
+
+See also: [[security]], [[testing]]
+
+## RAILS_MASTER_KEY Pattern
+
+Every Rails app encrypts credentials with a master key. In production, this key is provided via the `RAILS_MASTER_KEY` environment variable. Never commit the master key to source control (#554).
+
+With Kamal, secrets are managed through `.kamal/secrets`:
+
+```bash
+# .kamal/secrets
+RAILS_MASTER_KEY=$(op read "op://AppVault/myapp/RAILS_MASTER_KEY")
+```
+
+```yaml
+# config/deploy.yml
+env:
+  secret:
+    - RAILS_MASTER_KEY
+```
+
+Kamal reads `.kamal/secrets` at deploy time, resolves the values (in this case from 1Password via `op read`), and injects them as environment variables in the container.
+
+The pattern:
+1. Store the actual key in a secrets manager (1Password, AWS SSM, Vault)
+2. Reference it in `.kamal/secrets` using the appropriate CLI
+3. Declare it in `deploy.yml` under `env.secret`
+4. Rails reads `ENV["RAILS_MASTER_KEY"]` automatically
+
+## YAML Configuration DRYness — Anchor References
+
+YAML anchor references eliminate duplication across configuration files (#584).
+
+### Before — Repetitive Configuration
+
+```yaml
+# config/database.yml
+development:
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  host: localhost
+  database: myapp_development
+
+test:
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  host: localhost
+  database: myapp_test
+```
+
+### After — DRY with Anchors
+
+```yaml
+# config/database.yml
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: localhost
+
+development:
+  <<: *default
+  database: myapp_development
+
+test:
+  <<: *default
+  database: myapp_test
+
+production:
+  <<: *default
+  url: <%= ENV["DATABASE_URL"] %>
+```
+
+The `&default` defines an anchor. The `<<: *default` merges all key-value pairs from the anchor into the current mapping. Individual keys can be overridden after the merge.
+
+Apply this pattern to all YAML configuration files:
+
+```yaml
+# config/cable.yml
+default: &default
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+
+development:
+  <<: *default
+
+test:
+  adapter: test
+
+production:
+  <<: *default
+  url: <%= ENV["REDIS_URL"] %>
+```
+
+## Environment-Specific Configuration
+
+Be explicit about `RAILS_ENV`. Don't rely on defaults or assume what environment you're running in.
+
+### Environment Files Inherit from Production
+
+For environments that are "production-like" (beta, staging), inherit from the production config rather than duplicating it:
+
+```ruby
+# config/environments/beta.rb
+require_relative "production"
+
+Rails.application.configure do
+  # Only override what differs from production
+  config.log_level = :debug
+  config.action_mailer.default_url_options = { host: "beta.myapp.com" }
+end
+```
+
+```ruby
+# config/environments/staging.rb
+require_relative "production"
+
+Rails.application.configure do
+  # Staging-specific overrides
+  config.active_storage.service = :amazon_staging
+  config.action_mailer.default_url_options = { host: "staging.myapp.com" }
+end
+```
+
+This ensures beta and staging behave exactly like production except for the explicitly listed differences. No drift, no forgotten settings.
+
+## Test Environment Handling
+
+Avoid requiring credentials in the test environment. Tests should run without access to production secrets (#647).
+
+```ruby
+# BAD — tests fail without credentials file
+class PaymentService
+  def initialize
+    @api_key = Rails.application.credentials.stripe[:api_key]
+  end
+end
+
+# GOOD — fallback for test environment
+class PaymentService
+  def initialize
+    @api_key = Rails.application.credentials.dig(:stripe, :api_key) || ENV["STRIPE_API_KEY"] || "test_key"
+  end
+end
+```
+
+```ruby
+# BAD — initializer crashes in test
+# config/initializers/stripe.rb
+Stripe.api_key = Rails.application.credentials.stripe[:api_key]
+
+# GOOD — skip in test or use safe dig
+# config/initializers/stripe.rb
+if Rails.application.credentials.dig(:stripe, :api_key)
+  Stripe.api_key = Rails.application.credentials.stripe[:api_key]
+end
+```
+
+The principle: a fresh clone of the repo should be able to run `bin/rails test` without any credentials file or environment variables.
+
+## Environment Variable Precedence
+
+Environment variables take priority over credentials. This allows runtime overrides without redeploying or re-encrypting credentials (#1976).
+
+```ruby
+# ENV takes priority over credentials
+config.active_storage.service = ENV.fetch("STORAGE_SERVICE", Rails.application.credentials.dig(:storage, :service) || "local").to_sym
+```
+
+### Consistent Boolean ENV Vars
+
+Establish a convention for boolean environment variables and stick to it:
+
+```ruby
+# Pick a convention and use it everywhere
+def self.enabled?(key)
+  ENV[key].present? && ENV[key] != "false" && ENV[key] != "0"
+end
+
+# Usage
+if self.class.enabled?("FEATURE_NEW_DASHBOARD")
+  # ...
+end
+```
+
+```ruby
+# Or use Rails' built-in ActiveModel::Type::Boolean
+ActiveModel::Type::Boolean.new.cast(ENV["FEATURE_NEW_DASHBOARD"])
+# "true", "1", "yes" => true
+# "false", "0", "no", nil => false
+```
+
+## Development Environment Configuration
+
+### Feature Flags in Development
+
+Use environment variables for feature flags during development (#863):
+
+```ruby
+# config/environments/development.rb
+Rails.application.configure do
+  config.x.features.new_dashboard = ENV.fetch("FEATURE_NEW_DASHBOARD", "false") == "true"
+  config.x.features.ai_assistant = ENV.fetch("FEATURE_AI_ASSISTANT", "false") == "true"
+end
+```
+
+```ruby
+# In views or controllers
+if Rails.configuration.x.features.new_dashboard
+  render "dashboards/new_show"
+else
+  render "dashboards/show"
+end
+```
+
+### Development Scripts
+
+Use `bin/` scripts for common development tasks:
+
+```bash
+#!/bin/bash
+# bin/setup — idempotent setup script
+set -e
+
+echo "== Installing dependencies =="
+bundle install
+yarn install
+
+echo "== Preparing database =="
+bin/rails db:prepare
+
+echo "== Removing old logs and tempfiles =="
+bin/rails log:clear tmp:clear
+
+echo "== Done! =="
+```
+
+### Smart Seed Data
+
+Seed data should be idempotent and useful for development:
+
+```ruby
+# db/seeds.rb
+identity = Identity.find_or_create_by!(email: "dev@example.com")
+account = Account.find_or_create_by!(name: "Development")
+User.find_or_create_by!(identity: identity, account: account) do |user|
+  user.role = :admin
+end
+
+# Create realistic sample data
+10.times do |i|
+  project = account.projects.find_or_create_by!(name: "Project #{i + 1}") do |p|
+    p.description = "Sample project for development"
+  end
+
+  5.times do |j|
+    project.tasks.find_or_create_by!(title: "Task #{j + 1}") do |t|
+      t.position = j
+    end
+  end
+end
+```
+
+### Dynamic Dev Output
+
+Enable verbose logging in development without polluting production:
+
+```ruby
+# config/environments/development.rb
+Rails.application.configure do
+  config.log_level = ENV.fetch("LOG_LEVEL", "debug").to_sym
+
+  # Highlight SQL queries that take too long
+  config.active_record.warn_on_records_fetched_greater_than = 500
+
+  # Print deprecation notices
+  config.active_support.deprecation = :log
+
+  # Raise on missing translations
+  config.i18n.raise_on_missing_translations = true
+end
+```
+
+## Kamal Deployment Configuration
+
+### Secrets Pattern
+
+```bash
+# .kamal/secrets
+RAILS_MASTER_KEY=$(op read "op://AppVault/myapp/RAILS_MASTER_KEY")
+DATABASE_URL=$(op read "op://AppVault/myapp/DATABASE_URL")
+REDIS_URL=$(op read "op://AppVault/myapp/REDIS_URL")
+```
+
+### Environment-Specific Deploy Files
+
+Use separate deploy files for different environments:
+
+```yaml
+# config/deploy.yml (production)
+service: myapp
+image: myapp/myapp
+
+servers:
+  web:
+    hosts:
+      - 192.168.1.1
+      - 192.168.1.2
+    labels:
+      traefik.http.routers.myapp.rule: Host(`myapp.com`)
+
+env:
+  clear:
+    RAILS_ENV: production
+    RAILS_LOG_TO_STDOUT: true
+  secret:
+    - RAILS_MASTER_KEY
+    - DATABASE_URL
+    - REDIS_URL
+```
+
+```yaml
+# config/deploy.staging.yml
+service: myapp-staging
+image: myapp/myapp
+
+servers:
+  web:
+    hosts:
+      - 192.168.2.1
+    labels:
+      traefik.http.routers.myapp-staging.rule: Host(`staging.myapp.com`)
+
+env:
+  clear:
+    RAILS_ENV: staging
+    RAILS_LOG_TO_STDOUT: true
+  secret:
+    - RAILS_MASTER_KEY
+    - DATABASE_URL
+    - REDIS_URL
+```
+
+Deploy with: `kamal deploy -d staging`
+
+### Aliases
+
+Define Kamal aliases for common operations:
+
+```yaml
+# config/deploy.yml
+aliases:
+  console: app exec --interactive bin/rails console
+  logs: app logs -f
+  dbconsole: app exec --interactive bin/rails dbconsole
+  shell: app exec --interactive /bin/bash
+```
+
+Usage: `kamal console`, `kamal logs`, `kamal dbconsole`
+
+## Configuration Organization Principles
+
+1. **Secrets in a secrets manager, not in code.** Use `.kamal/secrets` to bridge between your secrets manager and the deployment environment. Never commit keys, tokens, or passwords.
+
+2. **DRY your YAML with anchors.** Every YAML config file should use `&default` anchors to avoid repeating shared settings across environments.
+
+3. **Environment files inherit, not duplicate.** Beta and staging should `require_relative "production"` and override only what differs. If you're copy-pasting a production config, you're doing it wrong.
+
+4. **Tests run without credentials.** A fresh clone with no credentials file and no environment variables must be able to run the full test suite. Use safe `dig` with fallbacks.
+
+5. **ENV overrides credentials.** Environment variables take priority over encrypted credentials, allowing runtime changes without redeployment.

--- a/compass/controllers.md
+++ b/compass/controllers.md
@@ -1,0 +1,489 @@
+---
+tags: [compass, rails, controllers, concerns]
+---
+
+# Controllers
+
+> Thin controllers, rich models, and composable concerns.
+
+See also: [[routing]], [[models]], [[views]]
+
+---
+
+## Core Principle: Thin Controllers, Rich Models
+
+Controllers should be thin orchestrators. Business logic lives in models.
+
+```ruby
+# GOOD: Controller just orchestrates
+class Cards::ClosuresController < ApplicationController
+  include CardScoped
+
+  def create
+    @card.close  # All logic in model
+
+    respond_to do |format|
+      format.turbo_stream { render_card_replacement }
+      format.json { head :no_content }
+    end
+  end
+
+  def destroy
+    @card.reopen  # All logic in model
+
+    respond_to do |format|
+      format.turbo_stream { render_card_replacement }
+      format.json { head :no_content }
+    end
+  end
+end
+```
+
+```ruby
+# BAD: Business logic in controller
+class Cards::ClosuresController < ApplicationController
+  def create
+    @card.transaction do
+      @card.create_closure!(user: Current.user)
+      @card.events.create!(action: :closed, creator: Current.user)
+      @card.watchers.each { |w| NotificationMailer.card_closed(w, @card).deliver_later }
+    end
+  end
+end
+```
+
+## ApplicationController is Minimal
+
+```ruby
+class ApplicationController < ActionController::Base
+  include Authentication
+  include Authorization
+  include BlockSearchEngineIndexing
+  include CurrentRequest, CurrentTimezone, SetPlatform
+  include RequestForgeryProtection
+  include TurboFlash, ViewTransitions
+  include RoutingHeaders
+
+  etag { "v1" }
+  stale_when_importmap_changes
+  allow_browser versions: :modern
+end
+```
+
+## Authorization: Controller Checks, Model Defines
+
+```ruby
+# Controller checks permission
+class CardsController < ApplicationController
+  before_action :ensure_permission_to_administer_card, only: [:destroy]
+
+  private
+    def ensure_permission_to_administer_card
+      head :forbidden unless Current.user.can_administer_card?(@card)
+    end
+end
+
+# Model defines what permission means
+class User < ApplicationRecord
+  def can_administer_card?(card)
+    admin? || card.creator == self
+  end
+
+  def can_administer_board?(board)
+    admin? || board.creator == self
+  end
+end
+```
+
+---
+
+## Controller Concerns Catalog
+
+Controller concerns create a vocabulary of reusable behaviors that compose beautifully.
+
+### Resource Scoping Concerns
+
+#### CardScoped - For Card Sub-resources
+
+```ruby
+module CardScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_card, :set_board
+  end
+
+  private
+    def set_card
+      @card = Current.user.accessible_cards.find_by!(number: params[:card_id])
+    end
+
+    def set_board
+      @board = @card.board
+    end
+
+    def render_card_replacement
+      render turbo_stream: turbo_stream.replace(
+        [@card, :card_container],
+        partial: "cards/container",
+        method: :morph,
+        locals: { card: @card.reload }
+      )
+    end
+end
+```
+
+**Usage Pattern:**
+
+```ruby
+class Cards::ClosuresController < ApplicationController
+  include CardScoped
+  def create
+    @card.close
+    respond_to do |format|
+      format.turbo_stream { render_card_replacement }
+      format.json { head :no_content }
+    end
+  end
+end
+
+class Cards::WatchesController < ApplicationController
+  include CardScoped
+  def create
+    @card.watch_by Current.user
+  end
+end
+
+class Cards::PinsController < ApplicationController
+  include CardScoped
+  def create
+    @pin = @card.pin_by Current.user
+  end
+end
+```
+
+**Key insight:** The concern provides `render_card_replacement` - a shared way to update the card UI.
+
+#### BoardScoped - For Board Sub-resources
+
+```ruby
+module BoardScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_board
+  end
+
+  private
+    def set_board
+      @board = Current.user.boards.find(params[:board_id])
+    end
+
+    def ensure_permission_to_admin_board
+      unless Current.user.can_administer_board?(@board)
+        head :forbidden
+      end
+    end
+end
+```
+
+#### ColumnScoped - For Column Sub-resources
+
+```ruby
+module ColumnScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_column
+  end
+
+  private
+    def set_column
+      @column = Current.user.accessible_columns.find(params[:column_id])
+    end
+end
+```
+
+---
+
+### Request Context Concerns
+
+#### CurrentRequest - Populate Current with Request Data
+
+```ruby
+module CurrentRequest
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.http_method = request.method
+      Current.request_id  = request.uuid
+      Current.user_agent  = request.user_agent
+      Current.ip_address  = request.ip
+      Current.referrer    = request.referrer
+    end
+  end
+end
+```
+
+Models and jobs can access request context via `Current` without parameter passing:
+
+```ruby
+class Signup
+  def create_identity
+    Identity.create!(
+      email_address: email_address,
+      ip_address: Current.ip_address,
+      user_agent: Current.user_agent
+    )
+  end
+end
+```
+
+#### CurrentTimezone - User Timezone from Cookie
+
+```ruby
+module CurrentTimezone
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :set_current_timezone
+    helper_method :timezone_from_cookie
+    etag { timezone_from_cookie }
+  end
+
+  private
+    def set_current_timezone(&)
+      Time.use_zone(timezone_from_cookie, &)
+    end
+
+    def timezone_from_cookie
+      @timezone_from_cookie ||= begin
+        timezone = cookies[:timezone]
+        ActiveSupport::TimeZone[timezone] if timezone.present?
+      end
+    end
+end
+```
+
+Key patterns:
+1. `around_action` wraps the entire request in the user's timezone
+2. `etag` includes timezone - different timezones get different cached responses
+3. Cookie is set client-side by JavaScript detecting the user's timezone
+
+#### SetPlatform - Detect Mobile/Desktop
+
+```ruby
+module SetPlatform
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :platform
+  end
+
+  private
+    def platform
+      @platform ||= ApplicationPlatform.new(request.user_agent)
+    end
+end
+```
+
+---
+
+### Filtering & Pagination Concerns
+
+#### FilterScoped - Complex Filtering
+
+```ruby
+module FilterScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_filter
+    before_action :set_user_filtering
+  end
+
+  private
+    def set_filter
+      if params[:filter_id].present?
+        @filter = Current.user.filters.find(params[:filter_id])
+      else
+        @filter = Current.user.filters.from_params(filter_params)
+      end
+    end
+
+    def filter_params
+      params.reverse_merge(**Filter.default_values)
+            .permit(*Filter::PERMITTED_PARAMS)
+    end
+
+    def set_user_filtering
+      @user_filtering = User::Filtering.new(Current.user, @filter, expanded: expanded_param)
+    end
+end
+```
+
+The Filter model does the heavy lifting:
+
+```ruby
+class Filter < ApplicationRecord
+  def cards
+    result = creator.accessible_cards.preloaded.published
+    result = result.indexed_by(indexed_by)
+    result = result.sorted_by(sorted_by)
+    result = result.where(board: boards.ids) if boards.present?
+    result = result.tagged_with(tags.ids) if tags.present?
+    result = result.assigned_to(assignees.ids) if assignees.present?
+    result.distinct
+  end
+end
+```
+
+Pattern: Filters are persisted! Users can save and name their filters.
+
+---
+
+### Security & Headers Concerns
+
+#### BlockSearchEngineIndexing
+
+```ruby
+module BlockSearchEngineIndexing
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :block_search_engine_indexing
+  end
+
+  private
+    def block_search_engine_indexing
+      headers["X-Robots-Tag"] = "none"
+    end
+end
+```
+
+#### RequestForgeryProtection - Modern CSRF
+
+```ruby
+module RequestForgeryProtection
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :append_sec_fetch_site_to_vary_header
+  end
+
+  private
+    def verified_request?
+      request.get? || request.head? || !protect_against_forgery? ||
+        (valid_request_origin? && safe_fetch_site?)
+    end
+
+    SAFE_FETCH_SITES = %w[same-origin same-site]
+
+    def safe_fetch_site?
+      SAFE_FETCH_SITES.include?(sec_fetch_site_value) ||
+        (sec_fetch_site_value.nil? && api_request?)
+    end
+end
+```
+
+Modern approach: Uses `Sec-Fetch-Site` header instead of tokens.
+
+---
+
+### Turbo/View Concerns
+
+#### TurboFlash - Flash Messages via Turbo Stream
+
+```ruby
+module TurboFlash
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :turbo_stream_flash
+  end
+
+  private
+    def turbo_stream_flash(**flash_options)
+      turbo_stream.replace(:flash, partial: "layouts/shared/flash", locals: { flash: flash_options })
+    end
+end
+```
+
+Usage:
+
+```ruby
+def create
+  @comment = @card.comments.create!(comment_params)
+  respond_to do |format|
+    format.turbo_stream do
+      render turbo_stream: [
+        turbo_stream.append(:comments, @comment),
+        turbo_stream_flash(notice: "Comment added!")
+      ]
+    end
+  end
+end
+```
+
+#### ViewTransitions - Disable on Refresh
+
+```ruby
+module ViewTransitions
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :disable_view_transitions, if: :page_refresh?
+  end
+
+  private
+    def disable_view_transitions
+      @disable_view_transition = true
+    end
+
+    def page_refresh?
+      request.referrer.present? && request.referrer == request.url
+    end
+end
+```
+
+---
+
+## Composing Concerns: Real Controllers
+
+```ruby
+class Cards::AssignmentsController < ApplicationController
+  include CardScoped
+
+  def new
+    @assigned_to = @card.assignees.active.alphabetically.where.not(id: Current.user)
+    @users = @board.users.active.alphabetically.where.not(id: @card.assignees)
+    fresh_when etag: [@users, @card.assignees]
+  end
+
+  def create
+    @card.toggle_assignment @board.users.active.find(params[:assignee_id])
+    respond_to do |format|
+      format.turbo_stream
+      format.json { head :no_content }
+    end
+  end
+end
+```
+
+## Concern Composition Rules
+
+1. **Concerns can include other concerns:**
+   ```ruby
+   module DayTimelinesScoped
+     include FilterScoped
+   end
+   ```
+
+2. **Use `before_action` in `included` block**
+
+3. **Provide shared private methods** (e.g. `render_card_replacement`)
+
+4. **Use `helper_method` for view access**
+
+5. **Add to `etag` for HTTP caching**

--- a/compass/css.md
+++ b/compass/css.md
@@ -1,0 +1,361 @@
+---
+tags: [compass, css, design, native-css]
+---
+
+# CSS Architecture
+
+> Native CSS with cascade layers, OKLCH colors, and modern features - no preprocessors.
+
+See also: [[views]], [[stimulus]], [[accessibility]]
+
+---
+
+## Philosophy
+
+Fizzy uses **native CSS only** - no Sass, PostCSS, or Tailwind. Modern CSS has everything needed:
+- Native nesting
+- CSS variables
+- Cascade layers
+- Container queries
+- OKLCH color space
+
+---
+
+## Cascade Layers
+
+```css
+@layer reset, base, layout, components, utilities;
+
+@layer reset {
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+}
+
+@layer base {
+  body {
+    font-family: system-ui, sans-serif;
+    line-height: 1.5;
+  }
+}
+
+@layer components {
+  .card { }
+  .btn { }
+}
+
+@layer utilities {
+  .hidden { display: none; }
+  .flex { display: flex; }
+}
+```
+
+Later layers always win, regardless of selector specificity.
+
+---
+
+## OKLCH Color Space
+
+```css
+:root {
+  --lch-blue-dark: 57.02% 0.1895 260.46;
+  --lch-blue-medium: 66% 0.196 257.82;
+  --lch-blue-light: 84.04% 0.0719 255.29;
+
+  --color-link: oklch(var(--lch-blue-dark));
+  --color-selected: oklch(var(--lch-blue-light));
+}
+```
+
+Benefits:
+- **Perceptually uniform** - Equal steps in lightness look equal
+- **P3 gamut support** - Wider color range on modern displays
+- **Easy theming** - Flip lightness values for dark mode
+
+---
+
+## Dark Mode via CSS Variables
+
+```css
+:root {
+  --lch-ink-darkest: 26% 0.05 264;
+  --lch-canvas: 100% 0 0;
+}
+
+html[data-theme="dark"] {
+  --lch-ink-darkest: 96.02% 0.0034 260;
+  --lch-canvas: 20% 0.0195 232.58;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    --lch-ink-darkest: 96.02% 0.0034 260;
+    --lch-canvas: 20% 0.0195 232.58;
+  }
+}
+```
+
+---
+
+## Native CSS Nesting
+
+```css
+.btn {
+  background-color: var(--btn-background);
+
+  @media (any-hover: hover) {
+    &:hover {
+      filter: brightness(var(--btn-hover-brightness));
+    }
+  }
+
+  html[data-theme="dark"] & {
+    --btn-hover-brightness: 1.25;
+  }
+
+  &[disabled] {
+    cursor: not-allowed;
+    opacity: 0.3;
+  }
+}
+```
+
+---
+
+## Component Naming Convention
+
+BEM-inspired but pragmatic:
+
+```css
+.card { }
+.card__header { }
+.card__body { }
+.card--notification { }
+.card--closed { }
+```
+
+Heavy use of CSS variables for theming + `:has()` selectors for parent-aware styling.
+
+---
+
+## CSS Variables for Component APIs
+
+```css
+.btn {
+  --btn-background: var(--color-canvas);
+  --btn-border-color: var(--color-ink-light);
+  --btn-color: var(--color-ink);
+  --btn-padding: 0.5em 1.1em;
+  --btn-border-radius: 99rem;
+
+  background-color: var(--btn-background);
+  border: 1px solid var(--btn-border-color);
+  color: var(--btn-color);
+  padding: var(--btn-padding);
+  border-radius: var(--btn-border-radius);
+}
+
+.btn--link {
+  --btn-background: var(--color-link);
+  --btn-color: var(--color-ink-inverted);
+}
+
+.btn--negative {
+  --btn-background: var(--color-negative);
+  --btn-color: var(--color-ink-inverted);
+}
+```
+
+---
+
+## Modern CSS Features Used
+
+### @starting-style for Entry Animations
+
+```css
+.dialog {
+  opacity: 0;
+  transform: scale(0.2);
+  transition: 150ms allow-discrete;
+  transition-property: display, opacity, overlay, transform;
+
+  &[open] {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  @starting-style {
+    &[open] {
+      opacity: 0;
+      transform: scale(0.2);
+    }
+  }
+}
+```
+
+### color-mix() for Dynamic Colors
+
+```css
+.card {
+  --card-bg-color: color-mix(in srgb, var(--card-color) 4%, var(--color-canvas));
+  --card-text-color: color-mix(in srgb, var(--card-color) 75%, var(--color-ink));
+}
+```
+
+### :has() for Parent-Aware Styling
+
+```css
+.btn:has(input:checked) {
+  --btn-background: var(--color-ink);
+  --btn-color: var(--color-ink-inverted);
+}
+
+.card:has(.card__closed) {
+  --card-color: var(--color-card-complete) !important;
+}
+```
+
+### Logical Properties
+
+```css
+.pad-block { padding-block: var(--block-space); }
+.pad-inline { padding-inline: var(--inline-space); }
+.margin-inline-start { margin-inline-start: var(--inline-space); }
+```
+
+### Container Queries
+
+```css
+.card__content {
+  contain: inline-size;
+}
+
+@container (width < 300px) {
+  .card__meta {
+    flex-direction: column;
+  }
+}
+```
+
+### Field Sizing
+
+```css
+.input--textarea {
+  @supports (field-sizing: content) {
+    field-sizing: content;
+    max-block-size: calc(3lh + (2 * var(--input-padding)));
+  }
+}
+```
+
+---
+
+## Utility Classes (Minimal)
+
+~60 focused utilities (unlike Tailwind's hundreds):
+
+```css
+@layer utilities {
+  .txt-small { font-size: var(--text-small); }
+  .txt-subtle { color: var(--color-ink-dark); }
+  .txt-center { text-align: center; }
+
+  .flex { display: flex; }
+  .gap { column-gap: var(--column-gap, var(--inline-space)); }
+  .stack { display: flex; flex-direction: column; }
+
+  .pad { padding: var(--block-space) var(--inline-space); }
+
+  .visually-hidden {
+    clip-path: inset(50%);
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+}
+```
+
+---
+
+## Design Tokens
+
+```css
+:root {
+  --inline-space: 1ch;
+  --block-space: 1rem;
+  --text-small: 0.85rem;
+  --text-normal: 1rem;
+  --text-large: 1.5rem;
+
+  @media (max-width: 639px) {
+    --text-small: 0.95rem;
+    --text-normal: 1.1rem;
+  }
+
+  --z-popup: 10;
+  --z-nav: 30;
+  --z-tooltip: 50;
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --dialog-duration: 150ms;
+}
+```
+
+---
+
+## Responsive Strategy
+
+Minimal breakpoints, mostly fluid:
+
+```css
+--main-padding: clamp(var(--inline-space), 3vw, calc(var(--inline-space) * 3));
+--tray-size: clamp(12rem, 25dvw, 24rem);
+
+@media (max-width: 639px) { /* Mobile */ }
+@media (min-width: 640px) { /* Desktop */ }
+@media (max-width: 799px) { /* Tablet and below */ }
+```
+
+---
+
+## File Organization
+
+One file per concern, ~100-300 lines each:
+
+```
+app/assets/stylesheets/
+├── _global.css          # CSS variables, layers, dark mode
+├── reset.css
+├── base.css
+├── layout.css
+├── utilities.css
+├── buttons.css
+├── cards.css
+├── inputs.css
+├── dialog.css
+├── popup.css
+└── application.css
+```
+
+---
+
+## What's NOT Here
+
+1. **No Sass/SCSS**
+2. **No PostCSS**
+3. **No Tailwind**
+4. **No CSS-in-JS**
+5. **No CSS Modules**
+6. **No !important abuse** - Layers handle specificity
+
+---
+
+## Key Principles
+
+1. **Use the platform** - Native CSS is capable
+2. **Design tokens everywhere** - Variables for consistency
+3. **Layers for specificity** - No specificity wars
+4. **Components own their styles** - Self-contained
+5. **Utilities are escape hatches** - Not the primary approach
+6. **Progressive enhancement** - `@supports` for new features
+7. **Minimal responsive** - Fluid over breakpoint-heavy

--- a/compass/database.md
+++ b/compass/database.md
@@ -1,0 +1,77 @@
+---
+tags: [rails, 37signals, database, uuid, solid-stack]
+---
+
+# Database Patterns
+
+> UUIDs, state as records, database-backed everything.
+
+See also: [[models]], [[multi-tenancy]], [[performance]]
+
+---
+
+## UUIDs as Primary Keys (UUIDv7)
+```ruby
+create_table :cards, id: :uuid do |t|
+  t.references :board, type: :uuid, foreign_key: true
+end
+```
+- No ID guessing/enumeration. Safe for distributed systems. Client can generate IDs.
+
+## State as Records — see [[models]]
+
+## Database-Backed Infrastructure (no Redis)
+
+### Solid Queue
+```ruby
+gem "solid_queue"
+# config/database.yml — separate queue database
+```
+
+### Solid Cache
+```ruby
+gem "solid_cache"
+config.cache_store = :solid_cache_store
+```
+
+### Solid Cable
+```ruby
+gem "solid_cable"
+# config/cable.yml
+production:
+  adapter: solid_cable
+```
+
+## Account ID Everywhere
+```ruby
+validates :number, uniqueness: { scope: :account_id }
+```
+
+## No Soft Deletes
+Hard delete records. Use events/audit logs for history.
+
+## Counter Caches
+```ruby
+has_many :cards, counter_cache: true
+```
+
+## Index Strategy
+```ruby
+add_index :cards, :board_id
+add_index :cards, [:account_id, :board_id, :created_at]
+```
+
+## Sharded Search (16 MySQL shards)
+```ruby
+def self.shard_for(account)
+  :"shard_#{Zlib.crc32(account.id.to_s) % 16}"
+end
+```
+
+## Key Principles
+1. UUIDs over integers
+2. State records over booleans
+3. Database-backed infra over Redis
+4. Hard deletes + audit logs
+5. Counter caches for common counts
+6. Index what you query

--- a/compass/dhh-patterns.md
+++ b/compass/dhh-patterns.md
@@ -1,0 +1,127 @@
+---
+tags: [rails, 37signals, dhh, code-review]
+---
+
+# DHH's Code Review Patterns
+
+> Extracted from 100+ PR reviews in Fizzy. Focus: Simplicity, directness, Rails conventions, fighting abstraction.
+
+See also: [[philosophy]], [[models]], [[views]], [[controllers]]
+
+---
+
+## Core: Earn Your Abstractions
+
+- Question every layer of indirection: "Is this abstraction earning its keep?"
+- If you can't point to 3+ variations that need it, inline it
+- Methods and classes that don't explain anything should be removed ("anemic" code)
+- Collapsed 6 notifier subclasses into 2
+
+## Database Over Application Logic
+
+```ruby
+# Avoided
+validates :code, uniqueness: true
+
+# Preferred - database constraint
+add_index :join_codes, :code, unique: true
+```
+
+When to validate: Only when you need user-facing error messages for form display.
+
+## Naming Principles
+
+```ruby
+# Avoid negative names
+scope :not_popped, -> { where(popped_at: nil) }
+# Prefer positive
+scope :active, -> { where(popped_at: nil) }
+```
+
+- `collect` implies returning an array — use `create_mentions` when you don't care about return value
+- Consistent domain language throughout
+- Method names should reflect their return value
+
+## Be Explicit Over Clever
+
+- When there are only 2-3 cases, explicit `case` statements beat metaprogramming
+- Don't add base class extensions for one-off methods — put them on the specific class
+- Define methods directly vs introspection
+
+## StringInquirer for Action Predicates
+
+```ruby
+def action
+  self[:action].inquiry
+end
+# event.action.completed? instead of event.action == "completed"
+```
+
+## Write-Time vs Read-Time Operations
+
+```ruby
+# Bad - computing at read time, can't paginate
+def thread_entries
+  (comments + events).sort_by(&:created_at)
+end
+
+# Good - delegated types, single-table query
+class Message < ApplicationRecord
+  delegated_type :messageable, types: %w[Comment EventSummary]
+end
+bubble.messages.order(:created_at).limit(20)
+```
+
+## View Patterns
+
+- If a partial has virtually no HTML and is mostly Ruby logic → helper or model method
+- Helpers should receive explicit parameters, not rely on magical ivars:
+```ruby
+# Bad
+def bubble_activity_count
+  @bubble.comments_count + @bubble.events_count
+end
+# Good
+def bubble_activity_count(bubble)
+  bubble.comments_count + bubble.events_count
+end
+```
+- Double-indent attributes in tag helpers
+- Use tag helpers for meta tags with interpolation
+- Turbo Stream canonical style: `turbo_stream.update [ @card, :new_comment ]`
+
+## Caching Principles
+
+- Use `touch: true` on associations rather than complex cache key dependencies
+- Use `update_all` for bulk updates when no side effects needed
+- Don't like base page cache dependent on anything beyond itself
+
+## API Design
+
+- Don't need `respond_to` block when templates exist for both formats
+- Inline Jbuilder: `json.steps @card.steps, partial: "steps/step", as: :step`
+- Prefer `head :no_content` for updates
+- Use `My::` namespace for Current user resources
+
+## Rails Conventions
+
+- Use `after_save_commit` instead of `after_commit on: %i[ create update ]`
+- Use `pluck(:name)` instead of `map(&:name)`
+- Delegate for lazy loading: `delegate :user, to: :session`
+- Touch chains for cache invalidation
+
+## Testing
+
+- Avoid test-induced design damage
+- Migrations can reference models — they were only ever meant to be transient
+
+## Key Takeaways
+
+1. **Abstractions must earn their keep** — inline if no variations
+2. **Write time > Read time** — compute when saving, not presenting
+3. **Database over AR** — prefer DB constraints
+4. **Positive names** — `active` not `not_deleted`
+5. **Explicit over clever** — case statements for 2-3 variations
+6. **Touch chains** — `touch: true` for cache invalidation
+7. **Helpers take params** — don't rely on magical ivars
+8. **Tests shouldn't shape design** — never add code just for testability

--- a/compass/email.md
+++ b/compass/email.md
@@ -1,0 +1,54 @@
+---
+tags: [rails, 37signals, email, mailers, smtp]
+---
+
+# Email
+
+> Multi-tenant mailers, timezone handling, SMTP resilience.
+
+See also: [[multi-tenancy]], [[notifications]], [[background-jobs]]
+
+---
+
+## Multi-Tenant URLs
+```ruby
+def default_url_options
+  Current.account ? super.merge(script_name: Current.account.slug) : super
+end
+```
+
+## Timezone Awareness
+```ruby
+def deliver
+  user.in_time_zone do
+    Current.with_account(user.account) { send_email }
+  end
+end
+```
+
+## SVG Fallbacks
+Replace SVG avatars with HTML/CSS initials — most email clients block SVG.
+
+## SMTP via ENV
+```ruby
+config.action_mailer.smtp_settings = {
+  address: ENV["SMTP_ADDRESS"],
+  port: ENV.fetch("SMTP_PORT", "587").to_i,
+  # ...
+}
+```
+
+## Error Handling
+- Retry: `Net::OpenTimeout`, `Net::SMTPServerBusy` (polynomial backoff)
+- Swallow: `550 5.1.1` (unknown), `552 5.6.0` (too large)
+- Apply globally: `ActionMailer::MailDeliveryJob.include SmtpDeliveryErrorHandling`
+
+## Batch: `ActiveJob.perform_all_later` for bulk enqueue
+
+## One-Click Unsubscribe (RFC 8058)
+```ruby
+headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+headers["List-Unsubscribe"] = "<#{unsubscribe_url(token: token)}>"
+```
+
+## Layout: table-based, inline styles, `mso-line-height-rule: exactly` for Outlook

--- a/compass/filtering.md
+++ b/compass/filtering.md
@@ -1,0 +1,737 @@
+---
+tags: [compass, rails, filtering, stimulus]
+see-also:
+  - "[[controllers]]"
+  - "[[stimulus]]"
+  - "[[models]]"
+---
+
+# Filtering
+
+## Filter Object Pattern - Evolution Journey (PRs #115, #116)
+
+### Before: Anti-Pattern Controller
+
+The controller was doing too much - mixing query logic with HTTP concerns:
+
+```ruby
+# Anti-pattern: controller doing filtering
+class BubblesController < ApplicationController
+  def index
+    @cards = current_bucket.cards
+    @cards = @cards.where(creator: current_user) if params[:mine]
+    @cards = @cards.where(status: params[:status]) if params[:status].present?
+    @cards = @cards.search(params[:query]) if params[:query].present?
+    @cards = @cards.where(assignee_id: params[:assignee]) if params[:assignee].present?
+    @cards = @cards.tagged_with(params[:tag]) if params[:tag].present?
+    @cards = @cards.due_before(params[:due_before]) if params[:due_before].present?
+    @cards = @cards.page(params[:page])
+  end
+end
+```
+
+### After: Clean Filter PORO
+
+Extract filtering into a plain Ruby object:
+
+```ruby
+# app/models/bucket/bubble_filter.rb
+class Bucket::BubbleFilter
+  include Filter::Params
+
+  attr_reader :bucket, :user, :params
+
+  def initialize(bucket:, user:, params: {})
+    @bucket = bucket
+    @user = user
+    @params = params.to_h.symbolize_keys
+  end
+
+  def cards
+    scope = bucket.cards.visible_to(user)
+    scope = filter_by_status(scope)
+    scope = filter_by_creator(scope)
+    scope = filter_by_assignee(scope)
+    scope = filter_by_tag(scope)
+    scope = filter_by_due_date(scope)
+    scope = search(scope)
+    scope
+  end
+
+  def any_active?
+    params.except(:sort).values.any?(&:present?)
+  end
+
+  private
+
+  def filter_by_status(scope)
+    return scope unless params[:status].present?
+    scope.where(status: params[:status])
+  end
+
+  def filter_by_creator(scope)
+    return scope if params[:mine].blank?
+    scope.where(creator: user)
+  end
+
+  def filter_by_assignee(scope)
+    return scope unless params[:assignee].present?
+    scope.where(assignee_id: params[:assignee])
+  end
+
+  def filter_by_tag(scope)
+    return scope unless params[:tag].present?
+    scope.tagged_with(params[:tag])
+  end
+
+  def filter_by_due_date(scope)
+    return scope unless params[:due_before].present?
+    scope.due_before(Date.parse(params[:due_before]))
+  end
+
+  def search(scope)
+    return scope unless params[:query].present?
+    scope.search(params[:query])
+  end
+end
+```
+
+The controller becomes trivial:
+
+```ruby
+class BubblesController < ApplicationController
+  def index
+    @filter = Bucket::BubbleFilter.new(
+      bucket: current_bucket,
+      user: current_user,
+      params: filter_params
+    )
+    @cards = @filter.cards.page(params[:page])
+  end
+
+  private
+
+  def filter_params
+    params.permit(:status, :mine, :assignee, :tag, :due_before, :query, :sort)
+  end
+end
+```
+
+---
+
+## Query Composition: Lazy Evaluation with Memoization
+
+The `Filter#cards` method composes scopes lazily - ActiveRecord only hits the database when results are enumerated:
+
+```ruby
+class Bucket::BubbleFilter
+  def cards
+    @cards ||= begin
+      scope = bucket.cards.visible_to(user)
+      scope = apply_status_filter(scope)
+      scope = apply_creator_filter(scope)
+      scope = apply_assignee_filter(scope)
+      scope = apply_tag_filter(scope)
+      scope = apply_due_date_filter(scope)
+      scope = apply_search(scope)
+      scope = apply_sort(scope)
+      scope
+    end
+  end
+
+  private
+
+  def apply_status_filter(scope)
+    case params[:status]
+    when "open"   then scope.open
+    when "closed" then scope.closed
+    when "archived" then scope.archived
+    else scope.active # default: open cards
+    end
+  end
+
+  def apply_creator_filter(scope)
+    return scope unless params[:mine].present?
+    scope.where(creator: user)
+  end
+
+  def apply_assignee_filter(scope)
+    return scope unless params[:assignee].present?
+    if params[:assignee] == "none"
+      scope.unassigned
+    else
+      scope.where(assignee_id: params[:assignee])
+    end
+  end
+
+  def apply_tag_filter(scope)
+    return scope unless params[:tag].present?
+    scope.tagged_with(params[:tag])
+  end
+
+  def apply_due_date_filter(scope)
+    return scope unless params[:due_before].present?
+    scope.due_before(Date.parse(params[:due_before]))
+  end
+
+  def apply_search(scope)
+    return scope unless params[:query].present?
+    scope.search(params[:query])
+  end
+
+  def apply_sort(scope)
+    case params[:sort]
+    when "newest"  then scope.order(created_at: :desc)
+    when "oldest"  then scope.order(created_at: :asc)
+    when "due"     then scope.order(due_on: :asc)
+    when "updated" then scope.order(updated_at: :desc)
+    else scope.order(position: :asc)
+    end
+  end
+end
+```
+
+Key insight: each `filter_by_*` method returns the scope unchanged if the param is blank, so filters compose cleanly without conditionals in the caller.
+
+---
+
+## URL-Based Filter State: Stateless Filtering
+
+### Filter::Params Module
+
+Filters are encoded in URL query parameters so they are bookmarkable, shareable, and work with back/forward navigation:
+
+```ruby
+# app/models/concerns/filter/params.rb
+module Filter::Params
+  extend ActiveSupport::Concern
+
+  PERMITTED_PARAMS = %i[ status mine assignee tag due_before query sort ].freeze
+
+  def as_params
+    params.slice(*PERMITTED_PARAMS).compact_blank
+  end
+
+  def as_params_without(*keys)
+    as_params.except(*keys)
+  end
+
+  def as_params_with(overrides)
+    as_params.merge(overrides).compact_blank
+  end
+
+  def active_param?(key)
+    params[key].present?
+  end
+
+  def active_params_count
+    as_params.size
+  end
+end
+```
+
+### FilterScoped Concern
+
+Applied to controllers that need filter state:
+
+```ruby
+# app/controllers/concerns/filter_scoped.rb
+module FilterScoped
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_filter
+  end
+
+  private
+
+  def current_filter
+    @current_filter ||= build_filter
+  end
+
+  def build_filter
+    filter_class.new(
+      bucket: current_bucket,
+      user: current_user,
+      params: filter_params
+    )
+  end
+
+  def filter_class
+    Bucket::BubbleFilter
+  end
+
+  def filter_params
+    params.permit(*Filter::Params::PERMITTED_PARAMS)
+  end
+end
+```
+
+URLs look like: `/buckets/123/cards?status=open&assignee=456&tag=urgent`
+
+---
+
+## Filter Chips as Links (PR #138)
+
+### Before: Form-Based (Anti-Pattern)
+
+```erb
+<%# Anti-pattern: form submission for filter removal %>
+<%= form_with url: cards_path, method: :get do |f| %>
+  <% current_filter.as_params.each do |key, value| %>
+    <% unless key == :status %>
+      <%= f.hidden_field key, value: value %>
+    <% end %>
+  <% end %>
+  <button type="submit" class="filter-chip">
+    Status: <%= params[:status] %> &times;
+  </button>
+<% end %>
+```
+
+### After: Link-Based (Clean)
+
+Filter chips are simple links that remove one filter parameter:
+
+```ruby
+# app/helpers/filters_helper.rb
+module FiltersHelper
+  def filter_chip_tag(label:, param:, filter:, path:)
+    remove_path = path.call(filter.as_params_without(param))
+
+    link_to remove_path, class: "filter-chip" do
+      concat content_tag(:span, label, class: "filter-chip__label")
+      concat content_tag(:span, "Remove", class: "filter-chip__remove visually-hidden")
+      concat icon("x", class: "filter-chip__icon")
+    end
+  end
+end
+```
+
+```erb
+<%# app/views/cards/_active_filters.html.erb %>
+<div class="active-filters" role="list" aria-label="Active filters">
+  <% if current_filter.active_param?(:status) %>
+    <%= filter_chip_tag(
+      label: "Status: #{params[:status].titleize}",
+      param: :status,
+      filter: current_filter,
+      path: ->(p) { bucket_cards_path(current_bucket, p) }
+    ) %>
+  <% end %>
+
+  <% if current_filter.active_param?(:assignee) %>
+    <%= filter_chip_tag(
+      label: "Assigned: #{User.find(params[:assignee]).name}",
+      param: :assignee,
+      filter: current_filter,
+      path: ->(p) { bucket_cards_path(current_bucket, p) }
+    ) %>
+  <% end %>
+
+  <% if current_filter.active_param?(:tag) %>
+    <%= filter_chip_tag(
+      label: "Tag: #{params[:tag]}",
+      param: :tag,
+      filter: current_filter,
+      path: ->(p) { bucket_cards_path(current_bucket, p) }
+    ) %>
+  <% end %>
+
+  <% if current_filter.any_active? %>
+    <%= link_to "Clear all", bucket_cards_path(current_bucket),
+      class: "filter-chip filter-chip--clear" %>
+  <% end %>
+</div>
+```
+
+### Testing Pattern
+
+```ruby
+class FiltersHelperTest < ActionView::TestCase
+  test "filter_chip_tag renders link to remove filter" do
+    filter = Bucket::BubbleFilter.new(
+      bucket: buckets(:one),
+      user: users(:one),
+      params: { status: "open", tag: "urgent" }
+    )
+
+    html = filter_chip_tag(
+      label: "Status: Open",
+      param: :status,
+      filter: filter,
+      path: ->(p) { bucket_cards_path(buckets(:one), p) }
+    )
+
+    assert_includes html, "tag=urgent"
+    refute_includes html, "status="
+    assert_includes html, "filter-chip"
+  end
+end
+```
+
+---
+
+## Stimulus Controllers for Filters (PR #567)
+
+### Filter Controller with Debounce
+
+Handles search input with debouncing to avoid excessive navigation:
+
+```javascript
+// app/javascript/controllers/filter_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "form"]
+  static values = {
+    debounce: { type: Number, default: 300 }
+  }
+
+  search() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      this.submitForm()
+    }, this.debounceValue)
+  }
+
+  submitForm() {
+    const url = new URL(this.formTarget.action)
+    const formData = new FormData(this.formTarget)
+
+    for (const [key, value] of formData) {
+      if (value) url.searchParams.set(key, value)
+    }
+
+    Turbo.visit(url.toString(), { action: "replace" })
+  }
+
+  clear() {
+    this.inputTarget.value = ""
+    this.submitForm()
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}
+```
+
+### Navigable List Controller with Keyboard Navigation
+
+Provides keyboard navigation for filter dropdowns:
+
+```javascript
+// app/javascript/controllers/navigable_list_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["item"]
+
+  connect() {
+    this.index = -1
+  }
+
+  keydown(event) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this.selectNext()
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.selectPrevious()
+        break
+      case "Enter":
+        event.preventDefault()
+        this.activateCurrent()
+        break
+      case "Space":
+        if (this.index >= 0) {
+          event.preventDefault()
+          this.activateCurrent()
+        }
+        break
+    }
+  }
+
+  selectNext() {
+    if (this.index < this.itemTargets.length - 1) {
+      this.index++
+      this.highlightCurrent()
+    }
+  }
+
+  selectPrevious() {
+    if (this.index > 0) {
+      this.index--
+      this.highlightCurrent()
+    }
+  }
+
+  highlightCurrent() {
+    this.itemTargets.forEach((item, i) => {
+      item.classList.toggle("navigable-list__item--highlighted", i === this.index)
+      item.setAttribute("aria-selected", i === this.index)
+    })
+    this.itemTargets[this.index]?.scrollIntoView({ block: "nearest" })
+  }
+
+  activateCurrent() {
+    const current = this.itemTargets[this.index]
+    if (current) {
+      const link = current.querySelector("a") || current
+      link.click()
+    }
+  }
+}
+```
+
+### View Integration with Dialog
+
+```erb
+<%# app/views/cards/_filter_bar.html.erb %>
+<div class="filter-bar" data-controller="filter">
+  <form action="<%= bucket_cards_path(current_bucket) %>"
+        method="get"
+        data-filter-target="form"
+        data-turbo-action="replace">
+
+    <input type="search"
+           name="query"
+           value="<%= params[:query] %>"
+           placeholder="Search cards..."
+           data-filter-target="input"
+           data-action="input->filter#search"
+           autocomplete="off" />
+
+    <button type="button"
+            data-action="filter#clear"
+            class="filter-bar__clear"
+            hidden>
+      Clear
+    </button>
+  </form>
+
+  <dialog id="filter-menu" class="filter-dialog">
+    <div data-controller="navigable-list"
+         data-action="keydown->navigable-list#keydown"
+         role="listbox"
+         aria-label="Filter options">
+
+      <h3 class="filter-dialog__heading">Status</h3>
+      <% %w[open closed archived].each do |status| %>
+        <%= link_to bucket_cards_path(current_bucket,
+              current_filter.as_params_with(status: status)),
+            class: "filter-dialog__item",
+            role: "option",
+            data: { navigable_list_target: "item" } do %>
+          <%= status.titleize %>
+          <% if params[:status] == status %>
+            <%= icon("check") %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <h3 class="filter-dialog__heading">Assignee</h3>
+      <% current_bucket.members.each do |member| %>
+        <%= link_to bucket_cards_path(current_bucket,
+              current_filter.as_params_with(assignee: member.id)),
+            class: "filter-dialog__item",
+            role: "option",
+            data: { navigable_list_target: "item" } do %>
+          <%= member.name %>
+        <% end %>
+      <% end %>
+    </div>
+  </dialog>
+</div>
+```
+
+---
+
+## Testing Filter Logic
+
+```ruby
+# test/models/bucket/bubble_filter_test.rb
+class Bucket::BubbleFilterTest < ActiveSupport::TestCase
+  setup do
+    @bucket = buckets(:first)
+    @user = users(:david)
+  end
+
+  test "cards returns only visible cards" do
+    filter = build_filter
+    cards = filter.cards
+
+    assert cards.all? { |c| c.visible_to?(@user) }
+  end
+
+  test "cards filters by status" do
+    filter = build_filter(status: "closed")
+
+    assert filter.cards.all? { |c| c.closed? }
+  end
+
+  test "cards filters by creator when mine is set" do
+    filter = build_filter(mine: "true")
+
+    assert filter.cards.all? { |c| c.creator == @user }
+  end
+
+  test "cards filters by assignee" do
+    assignee = users(:jason)
+    filter = build_filter(assignee: assignee.id)
+
+    assert filter.cards.all? { |c| c.assignee == assignee }
+  end
+
+  test "cards filters by tag" do
+    filter = build_filter(tag: "bug")
+
+    assert filter.cards.all? { |c| c.tags.include?("bug") }
+  end
+
+  test "permission boundaries are respected" do
+    outsider = users(:outsider)
+    filter = Bucket::BubbleFilter.new(
+      bucket: @bucket,
+      user: outsider,
+      params: {}
+    )
+
+    assert_empty filter.cards
+  end
+
+  test "remembering equivalent filters" do
+    filter_a = build_filter(status: "open", tag: "bug")
+    filter_b = build_filter(tag: "bug", status: "open")
+
+    assert_equal filter_a.digest_params, filter_b.digest_params
+  end
+
+  test "turning into params preserves only active filters" do
+    filter = build_filter(status: "open", tag: "", assignee: nil)
+
+    assert_equal({ status: "open" }, filter.as_params)
+  end
+
+  test "as_params_without removes specified keys" do
+    filter = build_filter(status: "open", tag: "bug")
+
+    result = filter.as_params_without(:status)
+    assert_equal({ tag: "bug" }, result)
+  end
+
+  test "any_active? returns true when filters are applied" do
+    assert build_filter(status: "open").any_active?
+    refute build_filter.any_active?
+  end
+
+  private
+
+  def build_filter(**params)
+    Bucket::BubbleFilter.new(bucket: @bucket, user: @user, params: params)
+  end
+end
+```
+
+---
+
+## Advanced Pattern: Filter Persistence with Digest
+
+Filters can be "remembered" so users return to their last-used filter state:
+
+```ruby
+# app/models/concerns/filter/rememberable.rb
+module Filter::Rememberable
+  extend ActiveSupport::Concern
+
+  def digest_params
+    normalize_params(as_params)
+  end
+
+  def remember
+    return unless any_active?
+
+    remembered_filter = RememberedFilter.find_or_initialize_by(
+      user: user,
+      bucket: bucket,
+      filterable_type: self.class.name
+    )
+
+    remembered_filter.update!(
+      params: as_params,
+      digest: digest_params
+    )
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  def remembered?
+    RememberedFilter.exists?(
+      user: user,
+      bucket: bucket,
+      filterable_type: self.class.name,
+      digest: digest_params
+    )
+  end
+
+  def restore
+    remembered = RememberedFilter.find_by(
+      user: user,
+      bucket: bucket,
+      filterable_type: self.class.name
+    )
+
+    return unless remembered
+
+    @params = remembered.params.symbolize_keys
+  end
+
+  private
+
+  def normalize_params(hash)
+    sorted = hash.sort_by { |k, _| k.to_s }.to_h
+    Digest::SHA256.hexdigest(sorted.to_json)
+  end
+end
+```
+
+```ruby
+# app/models/remembered_filter.rb
+class RememberedFilter < ApplicationRecord
+  belongs_to :user
+  belongs_to :bucket
+
+  validates :filterable_type, presence: true
+  validates :digest, presence: true
+end
+```
+
+Usage in the controller:
+
+```ruby
+class BubblesController < ApplicationController
+  include FilterScoped
+
+  def index
+    current_filter.restore if filter_params.empty?
+    current_filter.remember if filter_params.any?
+
+    @cards = current_filter.cards.page(params[:page])
+  end
+end
+```
+
+---
+
+## Summary: 7 Key Takeaways
+
+1. **Extract filter logic into POROs** - Controllers should delegate to filter objects, not contain query logic.
+2. **Compose scopes lazily** - Each filter method returns the scope unchanged if inactive, enabling clean chaining.
+3. **Use URL state for filters** - Query parameters make filters bookmarkable, shareable, and back-button compatible.
+4. **Filter chips are links, not forms** - Simple `<a>` tags that reconstruct the URL without the removed parameter.
+5. **Debounce search input** - Use Stimulus controllers to avoid excessive page navigations during typing.
+6. **Keyboard navigation is essential** - ArrowDown/Up, Enter, and Space for filter menus via a reusable Stimulus controller.
+7. **Persist filters with digests** - Normalize and hash filter params for idempotent storage with `RecordNotUnique` rescue for race conditions.

--- a/compass/hotwire.md
+++ b/compass/hotwire.md
@@ -1,0 +1,77 @@
+---
+tags: [rails, 37signals, hotwire, turbo, morphing]
+---
+
+# Hotwire Patterns
+
+> Turbo morphing, frames, state persistence, drag & drop.
+
+See also: [[stimulus]], [[views]], [[actioncable]]
+
+---
+
+## Turbo Morphing
+- Enable globally: `turbo_refreshes_with method: :morph, scroll: :preserve`
+- Listen for `turbo:morph-element` to restore client-side state
+- `data-turbo-permanent` for elements that shouldn't refresh
+- `refresh: :morph` on frames with `src` to prevent removal during morphs
+
+## Turbo Frames
+- Wrap form sections in frames to prevent reset on partial updates
+- Lazy-load: `loading: "lazy"`
+- `data-turbo-frame="_parent"` to target parent without knowing ID
+
+## State Persistence
+- localStorage for UI preferences
+- Restore on `turbo:morph-element` events
+- `nextFrame()` helper to wait for morph completion
+
+## Links Over JavaScript
+- Filter chips as plain `<a>` tags — right-click, cmd+click work
+- Better browser affordances, simpler code
+
+## Cached Fragment Personalization
+```javascript
+class Current {
+  get user() {
+    return { id: parseInt(document.head.querySelector('meta[name="current-user-id"]')?.content) }
+  }
+}
+window.Current = new Current()
+```
+```erb
+<meta name="current-user-id" content="<%= Current.user&.id %>">
+<div data-creator-id="<%= comment.creator_id %>" data-personalize-target="item">
+```
+
+## Progressive Installation
+```javascript
+connect() { this.element.classList.add("installed") }
+```
+```css
+.widget { visibility: hidden; }
+.widget.installed { visibility: visible; }
+```
+
+## Drag and Drop
+- `await nextFrame()` before applying drag classes
+- Track source container to prevent self-drop
+- Optimistically remove on drop
+- Let server handle ordering and re-render
+- Use `@rails/request.js`: `window.fetch = Turbo.fetch`
+
+## Testing Turbo Frames
+```ruby
+assert_turbo_frame "comments", loading: "lazy"
+assert_turbo_frame @user, :profile, target: "_top"
+assert_no_turbo_frame "admin-panel"
+```
+
+## Common Issues
+
+| Problem | Solution |
+|---------|----------|
+| Timers not updating after morph | Bind to `turbo:morph-element` |
+| Forms resetting on refresh | Wrap in turbo frames |
+| Flickering on replace | Use `method: :morph` |
+| localStorage state lost | Restore on `turbo:morph-element` |

--- a/compass/index.md
+++ b/compass/index.md
@@ -1,0 +1,79 @@
+---
+tags: [rails, 37signals, style-guide, compass]
+---
+
+# 37signals Rails Compass
+
+> Transferable Rails patterns and development philosophy extracted from 265 PRs in 37signals' Fizzy codebase.
+> Source: [unofficial-37signals-coding-style-guide](https://github.com/marckohlbrugge/unofficial-37signals-coding-style-guide)
+
+## Quick Start — The 37signals Way
+
+1. **Rich domain models** over service objects
+2. **CRUD controllers** over custom actions
+3. **Concerns** for horizontal code sharing
+4. **Records as state** over boolean columns
+5. **Database-backed everything** (no Redis)
+6. **Build it yourself** before reaching for gems
+7. **Ship to learn** - prototype quality is valid
+8. **Vanilla Rails is plenty** - maximize what Rails gives you
+
+---
+
+## Philosophy & Principles
+
+- [[philosophy]] — Ship, Validate, Refine & core development principles
+- [[dhh-patterns]] — DHH's code review patterns from 100+ PR reviews
+- [[jorge-manrubia]] — Architecture, Rails patterns & performance
+- [[jason-zimdars]] — Design, product & UX patterns
+- [[what-they-avoid]] — Gems and abstractions 37signals deliberately skips
+
+## Core Rails
+
+- [[routing]] — Everything is CRUD, noun-based resources
+- [[controllers]] — Thin controllers, rich models, concern catalog
+- [[models]] — Concerns, state records, POROs, scopes
+- [[views]] — Turbo Streams, partials, caching, helpers
+
+## Frontend
+
+- [[stimulus]] — Reusable controllers catalog & best practices
+- [[css]] — Native CSS, cascade layers, OKLCH, dark mode
+- [[hotwire]] — Turbo morphing, frames, state persistence, drag & drop
+- [[accessibility]] — ARIA, keyboard nav, screen readers, focus
+- [[mobile]] — Responsive design, touch optimization, safe areas
+
+## Backend
+
+- [[authentication]] — Passwordless magic links, sessions, rate limiting
+- [[multi-tenancy]] — Path-based tenancy, middleware, job preservation
+- [[database]] — UUIDs, state records, Solid Stack, indexing
+- [[background-jobs]] — Solid Queue, error handling, continuable jobs
+- [[caching]] — HTTP ETags, fragment caching, touch chains
+- [[performance]] — N+1, Puma tuning, lazy loading, preloaded scopes
+
+## Real-Time & Communication
+
+- [[actioncable]] — Multi-tenant WebSockets, scoped broadcasts, Solid Cable
+- [[notifications]] — Bundling, real-time via Turbo, email unsubscribe
+- [[email]] — Multi-tenant URLs, timezone awareness, SMTP resilience
+
+## Features
+
+- [[webhooks]] — SSRF protection, HMAC signatures, delinquency tracking
+- [[workflows]] — Event-driven state, undoable commands, custom Turbo actions
+- [[watching]] — Involvement enum, collection vs resource watching
+- [[filtering]] — Persisted filter objects, composable scopes
+- [[ai-llm]] — Command pattern, cost tracking, tool pattern
+
+## Rails Components
+
+- [[active-storage]] — Preprocessing, upload expiry, avatar optimization
+- [[action-text]] — Sanitizer config, autolinking, link retargeting
+
+## Infrastructure & Testing
+
+- [[security]] — XSS, CSRF, SSRF, CSP, rate limiting
+- [[testing]] — Minitest, fixtures, VCR, integration tests
+- [[configuration]] — Master key, YAML anchors, Kamal
+- [[observability]] — Structured logging, Yabeda metrics, console auditing

--- a/compass/jason-zimdars.md
+++ b/compass/jason-zimdars.md
@@ -1,0 +1,244 @@
+---
+tags:
+  - compass
+  - design
+  - ux
+  - css
+  - product
+see-also:
+  - "[[css]]"
+  - "[[philosophy]]"
+  - "[[views]]"
+---
+
+# Jason Zimdars' Design & Product Patterns
+
+> This document was AI-compiled from Jason Zimdars' (JZ) pull request comments, design decisions, and code review feedback across multiple PRs. Patterns were extracted and organized to serve as a reference for product and design thinking.
+
+## UX-First Decision Making
+
+### Perceived Performance > Technical Performance (PR #131)
+
+Jason consistently prioritizes how interactions *feel* over how they technically perform. In PR #131, reviewing a filtering UI, he noted:
+
+> "The filtering UI feels slow — like one of those shopping websites where you click a filter and the whole page reloads."
+
+The takeaway is not about milliseconds or benchmarks. It is about whether the user *perceives* the interaction as responsive. A technically fast operation that visually stutters or causes layout shift will feel worse than a slightly slower operation with smooth, predictable transitions.
+
+**Pattern:** When evaluating performance, ask "does this feel fast?" before asking "is this fast?" Optimize for perceived responsiveness — skeleton screens, optimistic updates, and smooth transitions matter more than shaving milliseconds off server response times.
+
+### Simplify by Removing, Not Just Hiding (PR #131)
+
+Rather than toggling visibility or layering UI states on top of each other, Jason advocates for genuinely simplifying what the user sees at any given moment:
+
+> "We shouldn't show the filter chips while the form is open. It's just noise at that point."
+
+This is a principle of *reducing cognitive load by subtraction*. When a user is actively editing filters in a form, showing the existing filter chips alongside the form creates redundant information. The user already knows what filters exist — they are editing them.
+
+**Pattern:** When a new UI state opens (a modal, a form, an expanded section), actively remove the elements it supersedes rather than simply overlaying the new state. Every visible element should earn its place in the current context.
+
+## Prototype Quality Shipping
+
+### Explicitly Label Implementation Quality (PR #335)
+
+Jason is transparent about the quality level of shipped code. In PR #335, he described his own implementation:
+
+> "This is prototype quality code."
+
+And followed it with a direct calibration for reviewers:
+
+> "Factor your appetite accordingly."
+
+This framing is powerful because it sets expectations without apology. It acknowledges that not all code needs to be production-hardened on the first pass, and it gives reviewers permission to focus on the *concept* rather than the *implementation details*.
+
+**Pattern:** When shipping exploratory or early-stage work, explicitly label it. Use clear language like "prototype quality" or "proof of concept" in PR descriptions. This prevents reviewers from spending time on polish that will be revisited, and it creates a shared understanding of what "done" means at this stage.
+
+### Ship to Validate, But Document Known Issues (PR #335)
+
+Jason ships work that he knows has flaws — but he enumerates those flaws upfront. In PR #335, the description included a structured list of known issues and areas that need future attention.
+
+**PR Description Template Pattern:**
+- What does this PR do? (one paragraph)
+- What is the quality level? (prototype / production-ready / needs-review)
+- What are the known issues? (numbered list)
+- What areas need future investigation? (numbered list)
+
+**Pattern:** Shipping imperfect work is fine — expected, even — but document what you know is wrong. This turns "technical debt" from a vague concern into a trackable, addressable list. It also shows reviewers that you are aware of the gaps, which builds trust.
+
+## Real Usage Trumps Speculation
+
+### Prefer Production Validation Over Local Perfection (PR #335)
+
+Jason explicitly chose to ship to production rather than continue perfecting locally. He noted the difference between synthetic and real-world conditions:
+
+> "Performance on Digital Ocean is going to be different from what we see locally. We need to get this in front of real data."
+
+**Decision Framework:**
+1. Does the feature work correctly in the happy path? Ship it.
+2. Are there known edge cases? Document them, ship anyway.
+3. Is performance uncertain? Production data will answer faster than local profiling.
+4. Is the UI rough? Real usage feedback will prioritize polish better than guessing.
+
+**Pattern:** When you are uncertain about performance, usability, or edge cases, production is a better laboratory than your local machine. Ship to validate, not to perfect.
+
+### Name Technical Debt, Don't Block on It (PR #335)
+
+Jason identifies technical debt with specificity rather than using it as a reason to delay shipping:
+
+> "The Bubble namespace is confusing here — it's doing too many things. But that's a refactor for another day."
+
+He names the problem (namespace confusion), acknowledges it, and explicitly defers it. This is different from ignoring technical debt — it is cataloging it while maintaining forward momentum.
+
+**Pattern:** When you encounter technical debt during a PR, name it specifically (what is wrong, where it lives, why it matters). Then explicitly decide: fix it now, or defer it. Never leave it unnamed — unnamed debt is invisible debt.
+
+## Incremental Feature Addition
+
+### Add Escape Hatches Without Removing Primary Path (PR #608)
+
+In PR #608, Jason added a "Create and add another" flow alongside the existing "Create" flow. The implementation used a `creation_type` parameter to differentiate between the two paths:
+
+```ruby
+# Controller implementation pattern
+def create
+  @record = Record.new(record_params)
+
+  if @record.save
+    if params[:creation_type] == "create_and_add_another"
+      redirect_to new_record_path, notice: "Created. Add another?"
+    else
+      redirect_to @record
+    end
+  else
+    render :new
+  end
+end
+```
+
+The key insight is that the new path (`create_and_add_another`) was added *alongside* the default path, not as a replacement. The primary "Create" button still works exactly as before. The new option is an escape hatch for power users who need to create multiple records in sequence.
+
+**Pattern:** When adding a new workflow variant, implement it as a parallel path with a distinguishing parameter. The original path should remain the default. New paths should be opt-in, never forced.
+
+## Visual Polish Through Iteration
+
+### Ship Visual Redesigns Big (PR #305)
+
+PR #305 touched 95 files in a single visual redesign. Jason chose to ship the redesign as one large PR rather than breaking it into incremental visual changes.
+
+The rationale: visual consistency matters. Shipping a redesign piecemeal creates a period where the application looks inconsistent — some screens have the new style, others have the old. This is jarring for users and creates confusion about which style is "correct" for developers working on other parts of the codebase.
+
+**Pattern:** Visual redesigns benefit from wholesale shipping. Unlike feature work (which should be incremental), design system changes and visual overhauls should land as a single, coordinated change. The temporary inconsistency of a piecemeal rollout is worse than the review burden of a large PR.
+
+## Feature Design Principles
+
+### Reuse Robust Systems for New Features (PR #335)
+
+When building new features, Jason looks for existing systems that already handle complexity well, rather than building from scratch:
+
+> "The filter system already handles all of this — multiple conditions, persistence, URL serialization. We should use it for this new feature too."
+
+In PR #335, he extended the existing filter infrastructure to support a new use case rather than building a parallel system. The form example followed the same principle — reusing the established form patterns rather than inventing a new approach.
+
+**Pattern:** Before building a new system, audit existing infrastructure. If a robust system already handles 80% of what you need, extend it rather than building from scratch. This reduces maintenance burden, leverages battle-tested code, and maintains consistency for users who already understand the existing patterns.
+
+## Feedback Style
+
+### Give Product Context, Not Implementation Mandates (PR #131)
+
+Jason's code review comments provide the *why* — the product reasoning — rather than dictating the *how*. His feedback often starts with phrases like:
+
+> "I'd imagined this working more like..."
+
+This framing is collaborative rather than directive. It shares his mental model without mandating a specific implementation. It gives the developer room to find a solution that achieves the product goal while respecting the technical constraints they understand best.
+
+**Pattern:** When giving feedback, lead with the product intent or user experience goal. Describe what you imagined the interaction feeling like, not what code to write. Use phrases like "I'd imagined...", "The goal here is...", "Users would expect..." to frame feedback in product terms.
+
+### Trust, Then Verify in Production (PR #335)
+
+Jason extends trust to the implementation while setting up verification:
+
+> "Factor your appetite accordingly."
+
+This phrase delegates judgment to the reviewer while implicitly saying: "I trust you to make the right call about how much to invest here." It is a form of empowerment — giving others the context they need to make decisions without micromanaging the outcome.
+
+**Pattern:** Set the context, share your assessment of quality and risk, then trust others to calibrate their response. Follow up by verifying in production rather than demanding perfection in review.
+
+## CSS Container Query Patterns (PRs #305, #335)
+
+Jason uses CSS container queries extensively for component-level responsive design. Rather than relying on viewport-based media queries, components respond to their own container's size.
+
+Key patterns from the PRs:
+
+- **Container query with `cqi` units:** Components use container query inline (cqi) units to size themselves relative to their container, not the viewport. This makes components truly portable — they adapt to wherever they are placed.
+
+```css
+.card {
+  container-type: inline-size;
+}
+
+.card__title {
+  font-size: clamp(1rem, 4cqi, 1.5rem);
+}
+
+@container (min-width: 300px) {
+  .card__layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+```
+
+- **Self-sizing cards:** Cards define their own container and respond to their own width. This eliminates the need for parent components to dictate child layout through props or classes.
+
+**Pattern:** Use `container-type: inline-size` on wrapper elements and `cqi` units for fluid sizing within those containers. Prefer container queries over media queries for any component that might appear in different layout contexts (sidebars, modals, main content area).
+
+## Data-Driven Development
+
+### List Specific Investigation Areas (PR #335)
+
+Rather than vaguely saying "we need to test this more," Jason lists specific, numbered areas of concern that need investigation:
+
+1. Performance with large datasets (500+ records)
+2. Behavior when filters return zero results
+3. Interaction between new filters and saved views
+4. URL serialization with special characters
+5. Mobile touch interaction with filter chips
+
+Each area is concrete enough to be assigned, tested, and resolved independently.
+
+**Pattern:** When identifying areas that need investigation, be specific and number them. Each item should be concrete enough that someone unfamiliar with the context could pick it up and investigate. Vague concerns ("performance might be an issue") are less actionable than specific ones ("performance with 500+ records in the unfiltered state").
+
+## Key Takeaways
+
+1. **Perceived performance matters more than technical performance.** Optimize for how interactions feel, not just how fast they are.
+2. **Label the quality level of your work explicitly.** "Prototype quality" is a valid and useful designation that sets expectations for everyone.
+3. **Ship to validate, don't polish to perfection locally.** Production data answers questions faster than local testing.
+4. **Name technical debt specifically.** Unnamed debt is invisible debt. Named debt is manageable debt.
+5. **Add new workflows as parallel paths, not replacements.** The primary path should remain untouched; new options are escape hatches.
+6. **Ship visual redesigns as a single coordinated change.** Piecemeal visual changes create inconsistency that is worse than a large PR.
+7. **Reuse existing robust systems rather than building new ones.** Extend what works before inventing something new.
+8. **Give product context in feedback, not implementation mandates.** Share the "why" and trust others to find the "how."
+
+## Application to Your Projects
+
+### PR Template Addition
+
+Add a shipping standard checklist to your PR template:
+
+```markdown
+## Shipping Standard
+- [ ] Quality level: (prototype / production-ready / needs-review)
+- [ ] Known issues documented: (list or "none")
+- [ ] Investigation areas identified: (numbered list or "none")
+- [ ] Perceived performance checked: (feels fast? transitions smooth?)
+- [ ] New UI states simplify rather than layer: (old elements removed when superseded?)
+```
+
+### Code Review Questions
+
+When reviewing PRs, ask these five questions inspired by Jason's patterns:
+
+1. **Does this feel fast?** Not "is this fast" — does the interaction *feel* responsive to a user? Are there optimistic updates, smooth transitions, or skeleton states?
+2. **What is the quality level?** Is this prototype-quality exploration or production-ready code? Has the author labeled it?
+3. **Are known issues documented?** If there are rough edges, are they enumerated? Can they be tracked independently?
+4. **Does new UI simplify or layer?** When a new state appears, does it remove the elements it supersedes, or does it pile on top of them?
+5. **Is this extending an existing system or inventing a new one?** If inventing, is there a good reason not to reuse what already exists?

--- a/compass/jorge-manrubia.md
+++ b/compass/jorge-manrubia.md
@@ -1,0 +1,177 @@
+---
+tags: [rails, 37signals, jorge-manrubia, architecture]
+---
+
+# Jorge Manrubia — Architecture & Rails Patterns
+
+> Focus: Architecture, Rails patterns, testing, and performance. Style: questions and suggestions, not mandates.
+
+See also: [[philosophy]], [[dhh-patterns]], [[performance]], [[caching]]
+
+---
+
+## Narrow Public APIs
+
+- Only expose what's actually used
+- "The narrower the public surface of a class the better"
+- Don't add public methods that aren't used anywhere
+
+```ruby
+# Bad - exposes internals
+class Quota
+  def reset_quota; end
+  def check_if_due_for_reset; end
+  def calculate_usage; end
+end
+
+# Good - narrow public API
+class Quota
+  def spend(cost); end
+  def ensure_not_depleted; end
+  private
+    def reset_if_due; end
+    def depleted?; end
+end
+```
+
+## Domain-Driven Naming
+
+```ruby
+quota.spend(cost)           # not increment_usage(cost)
+quota.ensure_not_depleted   # not ensure_under_limit
+quota.depleted?             # not over_limit?
+# "A quota is something you spend until you don't have anything left"
+```
+
+## Objects Emerge from Coupling
+
+When parameters get passed through multiple method layers, extract an object.
+
+```ruby
+# Smell: shared param coupling
+def cost(within:); end
+def cost_microcents(within:); end
+def limit_cost(within:); end
+
+# Solution: extract Ai::Quota model
+class Ai::Quota < ApplicationRecord
+  def spend(cost); end
+  def ensure_not_depleted; end
+end
+```
+
+## Concerns: Public Behavior Only
+
+```ruby
+# Bad - concern with only private methods
+module Ai::Quota::Resettable
+  private
+    def reset_if_due; end
+end
+
+# Good - inline private methods in main class
+class Ai::Quota
+  private
+    def reset_if_due; end
+end
+```
+
+Rule: Concerns = auxiliary public traits (Attachable, Named). Private methods = inline.
+
+## Memoize Hot Paths
+
+```ruby
+def as_params
+  @as_params ||= {}.tap do |params|
+    params[:indexed_by] = indexed_by
+  end
+end
+```
+
+"This method is invoked many times during page rendering and triggers many queries."
+
+## Layer Caching
+
+- HTTP cache (`fresh_when`) — full response
+- Column cache — shared across users with same events
+- Filter menu — per-user, reused across pages
+- Timezone in etag for user-specific rendering
+
+## Fixed-Point for Money
+
+```ruby
+class Ai::Quota::Money < Data.define(:value)
+  MICROCENTS_PER_DOLLAR = 100 * 1_000_000
+
+  def self.convert_dollars_to_microcents(dollars)
+    (dollars.to_d * MICROCENTS_PER_DOLLAR).round.to_i
+  end
+
+  def in_dollars
+    value.to_d / MICROCENTS_PER_DOLLAR
+  end
+end
+```
+
+Why microcents? LLM costs are fractions of a cent. SQLite DECIMAL is backed by float.
+
+## Time-Based Reset Without Cron
+
+```ruby
+def spend(cost)
+  transaction do
+    reset_if_due
+    increment!(:used, cost.in_microcents)
+  end
+end
+
+private
+  def reset_if_due
+    reset if due_for_reset?
+  end
+```
+
+"We can get by without the Cron job by checking when it's incremented."
+
+## VCR for External APIs
+
+```ruby
+VCR.configure do |config|
+  config.cassette_library_dir = "test/vcr_cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data('<API_KEY>') { Rails.application.credentials.openai.api_key }
+end
+```
+
+To update: `VCR_RECORD=1 bin/rails test`
+
+## Custom Types: Only When Justified
+
+If money conversion only happens in one place, a value object is enough. Custom Active Model types only when spread across many models.
+
+## Error Handling: Specific Errors
+
+```ruby
+class Ai::Quota::UsageExceedsQuotaError < StandardError; end
+
+def ensure_not_depleted
+  raise UsageExceedsQuotaError if depleted?
+end
+
+# Controller
+rescue_from Ai::Quota::UsageExceedsQuotaError do
+  render json: { error: "You've depleted your quota" }, status: :too_many_requests
+end
+```
+
+## Key Takeaways
+
+1. **Narrow public APIs** — only expose what's used
+2. **Domain names** — `depleted?` not `over_limit?`
+3. **Objects from coupling** — shared params → extract object
+4. **Memoize hot paths** — methods called during rendering
+5. **Layer caching** — HTTP, templates, queries
+6. **Fixed-point money** — integers, not floats
+7. **Reset on use** — simpler than cron
+8. **VCR for APIs** — fast, deterministic tests
+9. **Teach through questions** — "What do you think of..." not "Change this to..."

--- a/compass/mobile.md
+++ b/compass/mobile.md
@@ -1,0 +1,50 @@
+---
+tags: [rails, 37signals, mobile, responsive, css]
+---
+
+# Mobile
+
+> Responsive CSS, safe area insets, touch optimization.
+
+See also: [[css]], [[accessibility]], [[hotwire]]
+
+---
+
+## Responsive Patterns
+- Negative margins to reclaim padding on mobile
+- Stacked-to-grid: `grid-template-columns: repeat(2, 50%)` at 640px+
+- Sticky headers with z-index management for dialogs
+- Icon + badge navigation on mobile
+- Viewport-adaptive limits: `(min-height)` and `(max-height)`
+
+## Mobile-First CSS
+- `clamp()` for fluid typography: `font-size: clamp(var(--text-medium), 6vw, var(--text-xx-large))`
+- Responsive custom properties at breakpoints
+- Conditional borders on mobile for visual separation
+- Hide empty rich text: `p:only-child:has(br:only-child) { display: none; }`
+
+## Touch Optimization
+- Circle buttons on mobile (icon-only, hide text)
+- Full-width touch targets on expand
+- Disable empty states: `pointer-events: none` + `opacity: 0.5`
+- Min touch target: 44x44px (iOS) / 48x48px (Android)
+
+## Safe Area Insets
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
+```
+```css
+#header { padding-top: calc(var(--block-space-half) + env(safe-area-inset-top)); }
+.tray { inset-block: auto env(safe-area-inset-bottom); }
+```
+Critical: `viewport-fit=cover` required for safe-area to work.
+
+## Checklist
+- [ ] Viewport meta with `viewport-fit=cover`
+- [ ] Safe area insets on header/footer
+- [ ] `clamp()` for fluid typography
+- [ ] Touch targets ≥ 44x44px
+- [ ] Stacked layouts on mobile
+- [ ] Dark mode backgrounds
+- [ ] Logical properties for RTL support
+- [ ] `dvw`/`dvh` dynamic viewport units

--- a/compass/models.md
+++ b/compass/models.md
@@ -1,0 +1,183 @@
+---
+tags: [rails, 37signals, models, concerns, activerecord]
+---
+
+# Models
+
+> Rich domain models with composable concerns and state as records.
+
+See also: [[philosophy]], [[dhh-patterns]], [[database]]
+
+---
+
+## Heavy Use of Concerns
+
+```ruby
+class Card < ApplicationRecord
+  include Assignable, Attachments, Broadcastable, Closeable, Colored,
+    Entropic, Eventable, Exportable, Golden, Mentions, Multistep,
+    Pinnable, Postponable, Promptable, Readable, Searchable, Stallable,
+    Statuses, Storage::Tracked, Taggable, Triageable, Watchable
+end
+```
+
+## Concern Structure: Self-Contained
+
+```ruby
+module Card::Closeable
+  extend ActiveSupport::Concern
+  included do
+    has_one :closure, dependent: :destroy
+    scope :closed, -> { joins(:closure) }
+    scope :open, -> { where.missing(:closure) }
+  end
+
+  def closed?
+    closure.present?
+  end
+
+  def close(user: Current.user)
+    unless closed?
+      transaction do
+        create_closure! user: user
+        track_event :closed, creator: user
+      end
+    end
+  end
+
+  def reopen(user: Current.user)
+    if closed?
+      transaction do
+        closure&.destroy
+        track_event :reopened, creator: user
+      end
+    end
+  end
+end
+```
+
+## State as Records, Not Booleans
+
+```ruby
+# BAD
+class Card < ApplicationRecord
+  scope :closed, -> { where(closed: true) }
+end
+
+# GOOD
+class Closure < ApplicationRecord
+  belongs_to :card, touch: true
+  belongs_to :user, optional: true
+  # created_at = when, user = who
+end
+
+class Card < ApplicationRecord
+  has_one :closure, dependent: :destroy
+  scope :closed, -> { joins(:closure) }
+  scope :open, -> { where.missing(:closure) }
+end
+```
+
+### Real State Record Examples
+- `Closure` — who/when closed a card
+- `Card::Goldness` — marks as "golden"
+- `Card::NotNow` — postponed
+- `Board::Publication` — publicly published (has `has_secure_token :key`)
+
+## Default Values via Lambdas
+
+```ruby
+belongs_to :account, default: -> { board.account }
+belongs_to :creator, class_name: "User", default: -> { Current.user }
+```
+
+## Current for Request Context
+
+```ruby
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session, :user, :identity, :account
+  attribute :http_method, :request_id, :user_agent, :ip_address, :referrer
+end
+```
+
+## Minimal Validations
+
+```ruby
+class Account < ApplicationRecord
+  validates :name, presence: true  # That's it
+end
+```
+
+Prefer DB constraints. Contextual validations: `validates :full_name, presence: true, on: :completion`
+
+## Let It Crash (Bang Methods)
+
+```ruby
+@comment = @card.comments.create!(comment_params)
+```
+
+## Callbacks: Used Sparingly
+
+Only 38 occurrences across 30 files. For setup/cleanup, NOT business logic.
+
+## PORO Patterns
+
+```ruby
+# Presentation logic
+class Event::Description
+  def to_s
+    case event.action
+    when "created" then "#{creator_name} created this card"
+    when "closed" then "#{creator_name} closed this card"
+    end
+  end
+end
+
+# View context bundling
+class User::Filtering
+  attr_reader :user, :filter, :expanded
+  def boards; user.boards.accessible; end
+  def assignees; user.account.users.active.alphabetically; end
+end
+```
+
+POROs are model-adjacent, NOT service objects (controller-adjacent).
+
+## Scope Naming
+
+```ruby
+# Good - business-focused
+scope :active, -> { where.missing(:pop) }
+scope :unassigned, -> { where.missing(:assignments) }
+
+# Bad - SQL-ish
+scope :without_pop, -> { ... }
+```
+
+### Common Patterns
+```ruby
+scope :alphabetically, -> { order(title: :asc) }
+scope :recently_created, -> { order(created_at: :desc) }
+scope :assigned_to, ->(user) { joins(:assignments).where(assignments: { user: user }) }
+scope :tagged_with, ->(tag_ids) { joins(:taggings).where(taggings: { tag_id: tag_ids }) }
+scope :preloaded, -> { includes(:creator, :board, :tags, :assignments, :closure) }
+```
+
+## Concern Organization
+
+1. Each concern: **50-150 lines**
+2. Must be **cohesive** — related functionality together
+3. Don't create concerns just to reduce file size
+4. Name for capability: `Closeable`, `Watchable`, `Assignable`
+
+## Touch Chains for Cache Invalidation
+
+```ruby
+class Comment < ApplicationRecord
+  has_one :message, as: :messageable, touch: true
+end
+class Message < ApplicationRecord
+  belongs_to :bubble, touch: true
+end
+# comment → message → bubble cache invalidation
+```

--- a/compass/multi-tenancy.md
+++ b/compass/multi-tenancy.md
@@ -1,0 +1,73 @@
+---
+tags: [rails, 37signals, multi-tenancy, middleware]
+---
+
+# Multi-Tenancy
+
+> URL path-based tenancy. No wildcard DNS/SSL. Shared database with `account_id`.
+
+See also: [[authentication]], [[database]], [[actioncable]], [[email]]
+
+---
+
+## Path-Based Middleware
+```ruby
+class AccountSlug::Extractor
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+    if request.path_info =~ PATH_INFO_MATCH
+      request.engine_script_name = request.script_name = $1
+      request.path_info = $'.empty? ? "/" : $'
+      env["fizzy.external_account_id"] = AccountSlug.decode($2)
+    end
+    if env["fizzy.external_account_id"]
+      account = Account.find_by(external_account_id: env["fizzy.external_account_id"])
+      Current.with_account(account) { @app.call(env) }
+    else
+      Current.without_account { @app.call(env) }
+    end
+  end
+end
+```
+
+## ActiveJob Tenant Preservation
+```ruby
+module FizzyActiveJobExtensions
+  def initialize(...)
+    super
+    @account = Current.account
+  end
+  def serialize
+    super.merge({ "account" => @account&.to_gid })
+  end
+  def perform_now
+    account.present? ? Current.with_account(account) { super } : super
+  end
+end
+```
+
+## Always Scope Lookups
+```ruby
+# Bad
+@comment = Comment.find(params[:comment_id])
+# Good
+@comment = Current.account.comments.find(params[:comment_id])
+# Better
+@bubble = Current.user.accessible_bubbles.find(params[:bubble_id])
+```
+
+## Recurring Jobs: Iterate All Tenants
+```ruby
+class AutoPopAllDueJob < ApplicationJob
+  def perform
+    ApplicationRecord.with_each_tenant { |t| Bubble.auto_pop_all_due }
+  end
+end
+```
+
+## Session Cookie Path Scoping
+Path scope cookies to prevent cross-tenant clobbering.
+
+## Architecture Decision
+Path-based tenancy with shared database (not database-per-tenant).
+URLs: `/1234567/boards/123`. Simpler than subdomains for local dev.

--- a/compass/notifications.md
+++ b/compass/notifications.md
@@ -1,0 +1,888 @@
+---
+tags: [compass, rails, notifications, turbo]
+see-also:
+  - "[[email]]"
+  - "[[background-jobs]]"
+  - "[[hotwire]]"
+---
+
+# Notifications
+
+## Read State Management with Timestamps (PR #208)
+
+Use `read_at` timestamp instead of a boolean for richer querying:
+
+```ruby
+# app/models/notification.rb
+class Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :actor, class_name: "User", optional: true
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+  scope :newest_first, -> { order(created_at: :desc) }
+  scope :for_card, ->(card) { where(notifiable: card) }
+
+  def read?
+    read_at.present?
+  end
+
+  def unread?
+    !read?
+  end
+
+  def mark_as_read
+    update!(read_at: Time.current) if unread?
+  end
+
+  def self.read_all
+    unread.update_all(read_at: Time.current)
+  end
+end
+```
+
+Benefits over a boolean:
+- Know **when** something was read (audit trail)
+- Query "read in the last hour" for analytics
+- `unread` scope is simply `where(read_at: nil)` - clean and indexable
+
+---
+
+## Notification Bundling with Time Windows (PR #974)
+
+Bundle multiple notifications into a single digest to avoid overwhelming users:
+
+```ruby
+# app/models/notification/bundle.rb
+class Notification::Bundle < ApplicationRecord
+  belongs_to :user
+
+  enum :status, { pending: 0, delivered: 1, skipped: 2 }
+
+  scope :deliverable, -> {
+    pending.where(deliver_after: ..Time.current)
+  }
+
+  scope :for_user, ->(user) { where(user: user) }
+
+  # No FK to notifications - bundles aggregate by time window
+  # Notifications belong to a bundle via time range overlap
+
+  def notifications
+    user.notifications.where(created_at: window_start..window_end)
+  end
+
+  def window_start
+    created_at
+  end
+
+  def window_end
+    created_at + user.settings.bundle_aggregation_period
+  end
+
+  validate :no_overlapping_bundles
+
+  private
+
+  def no_overlapping_bundles
+    overlapping = self.class
+      .for_user(user)
+      .pending
+      .where.not(id: id)
+      .where("deliver_after > ? AND created_at < ?", window_start, window_end)
+
+    if overlapping.exists?
+      errors.add(:base, "overlaps with an existing pending bundle")
+    end
+  end
+end
+```
+
+---
+
+## User Preference Architecture with Settings Model (PR #974)
+
+### User::Configurable Concern
+
+```ruby
+# app/models/concerns/user/configurable.rb
+module User::Configurable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :settings, class_name: "User::Settings", dependent: :destroy
+
+    after_create :create_default_settings
+  end
+
+  def settings
+    super || create_default_settings
+  end
+
+  private
+
+  def create_default_settings
+    create_settings!
+  end
+end
+```
+
+### User::Settings Model
+
+```ruby
+# app/models/user/settings.rb
+class User::Settings < ApplicationRecord
+  belongs_to :user
+
+  enum :bundle_email_frequency, {
+    immediately: 0,
+    hourly: 1,
+    daily: 2,
+    weekly: 3,
+    never: 4
+  }, prefix: :email
+
+  def bundle_aggregation_period
+    case bundle_email_frequency
+    when "immediately" then 0.minutes
+    when "hourly"      then 1.hour
+    when "daily"       then 1.day
+    when "weekly"      then 1.week
+    when "never"       then nil
+    end
+  end
+
+  def wants_email_notifications?
+    !email_never?
+  end
+
+  # Reactive: changing frequency reschedules pending bundles
+  after_update :reschedule_pending_bundles, if: :saved_change_to_bundle_email_frequency?
+
+  private
+
+  def reschedule_pending_bundles
+    user.notification_bundles.pending.find_each do |bundle|
+      if wants_email_notifications?
+        bundle.update!(deliver_after: bundle.created_at + bundle_aggregation_period)
+      else
+        bundle.skipped!
+      end
+    end
+  end
+end
+```
+
+---
+
+## Automatic Bundling via Callbacks (PR #974)
+
+### after_create :bundle
+
+```ruby
+# app/models/notification.rb
+class Notification < ApplicationRecord
+  after_create_commit :bundle
+
+  private
+
+  def bundle
+    return unless user.settings.wants_email_notifications?
+
+    user.find_or_create_bundle_for(self)
+  end
+end
+```
+
+### User::Notifiable Concern
+
+```ruby
+# app/models/concerns/user/notifiable.rb
+module User::Notifiable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :notifications, dependent: :destroy
+    has_many :notification_bundles,
+      class_name: "Notification::Bundle",
+      dependent: :destroy
+  end
+
+  def find_or_create_bundle_for(notification)
+    period = settings.bundle_aggregation_period
+    return deliver_immediately(notification) if period.zero?
+
+    existing_bundle = notification_bundles
+      .pending
+      .where("created_at > ?", period.ago)
+      .first
+
+    if existing_bundle
+      # Notification falls within existing bundle window
+      existing_bundle
+    else
+      notification_bundles.create!(
+        status: :pending,
+        deliver_after: Time.current + period
+      )
+    end
+  end
+
+  private
+
+  def deliver_immediately(notification)
+    Notification::DeliverJob.perform_later(notification)
+  end
+end
+```
+
+---
+
+## Background Job Pattern for Batch Delivery (PR #974)
+
+### DeliverAllJob with Multi-Tenant Support
+
+```ruby
+# app/jobs/notification/deliver_all_job.rb
+class Notification::DeliverAllJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Account.find_each do |account|
+      account.with do
+        deliver_bundles_for_account
+      end
+    end
+  end
+
+  private
+
+  def deliver_bundles_for_account
+    Notification::Bundle.deliverable.find_each do |bundle|
+      deliver_bundle(bundle)
+    end
+  end
+
+  def deliver_bundle(bundle)
+    notifications = bundle.notifications.unread
+
+    if notifications.any?
+      NotificationMailer.bundle(
+        user: bundle.user,
+        notifications: notifications
+      ).deliver_now
+
+      bundle.delivered!
+    else
+      bundle.skipped!
+    end
+  rescue => error
+    Rails.logger.error("Failed to deliver bundle #{bundle.id}: #{error.message}")
+  end
+end
+```
+
+### perform_all_later and recurring.yml
+
+```ruby
+# For dispatching multiple jobs at once
+Notification::DeliverJob.perform_all_later(
+  notifications.map { |n| Notification::DeliverJob.new(n) }
+)
+```
+
+```yaml
+# config/recurring.yml
+notification_delivery:
+  class: Notification::DeliverAllJob
+  schedule: every 5 minutes
+  queue: default
+```
+
+---
+
+## Turbo Streams for Real-Time Notification UI (PR #475)
+
+### Broadcasting Read/Unread State
+
+```ruby
+# app/models/notification.rb
+class Notification < ApplicationRecord
+  after_update_commit :broadcast_read, if: :saved_change_to_read_at?
+
+  def broadcast_unread
+    broadcast_prepend_to(
+      user, :notifications,
+      target: "notifications",
+      partial: "notifications/notification",
+      locals: { notification: self }
+    )
+
+    broadcast_update_to(
+      user, :notification_badge,
+      target: "notification_badge",
+      partial: "notifications/badge",
+      locals: { count: user.notifications.unread.count }
+    )
+  end
+
+  def broadcast_read
+    broadcast_replace_to(
+      user, :notifications,
+      target: dom_id(self),
+      partial: "notifications/notification",
+      locals: { notification: self }
+    )
+
+    broadcast_update_to(
+      user, :notification_badge,
+      target: "notification_badge",
+      partial: "notifications/badge",
+      locals: { count: user.notifications.unread.count }
+    )
+  end
+end
+```
+
+### View Setup
+
+```erb
+<%# app/views/notifications/index.html.erb %>
+<%= turbo_stream_from current_user, :notifications %>
+<%= turbo_stream_from current_user, :notification_badge %>
+
+<div id="notification_badge">
+  <%= render "notifications/badge", count: current_user.notifications.unread.count %>
+</div>
+
+<div id="notifications">
+  <%= render partial: "notifications/notification",
+    collection: @notifications %>
+</div>
+```
+
+```erb
+<%# app/views/notifications/_notification.html.erb %>
+<%= turbo_frame_tag dom_id(notification) do %>
+  <div class="notification <%= 'notification--unread' if notification.unread? %>">
+    <p><%= notification.actor&.name %> <%= notification.action %></p>
+    <time datetime="<%= notification.created_at.iso8601 %>">
+      <%= time_ago_in_words(notification.created_at) %> ago
+    </time>
+
+    <% if notification.unread? %>
+      <%= button_to "Mark read",
+        notification_reading_path(notification),
+        method: :post,
+        class: "notification__mark-read" %>
+    <% end %>
+  </div>
+<% end %>
+```
+
+---
+
+## Pagination with Infinite Scroll via Intersection Observer (PR #208)
+
+### fetch-on-visible Stimulus Controller
+
+```javascript
+// app/javascript/controllers/fetch_on_visible_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    url: String
+  }
+
+  connect() {
+    this.observer = new IntersectionObserver(
+      (entries) => this.handleIntersection(entries),
+      { rootMargin: "100px" }
+    )
+    this.observer.observe(this.element)
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
+  }
+
+  async handleIntersection(entries) {
+    const entry = entries[0]
+    if (!entry.isIntersecting) return
+
+    this.observer.disconnect()
+
+    const response = await fetch(this.urlValue, {
+      headers: {
+        Accept: "text/vnd.turbo-stream.html"
+      }
+    })
+
+    if (response.ok) {
+      const html = await response.text()
+      Turbo.renderStreamMessage(html)
+    }
+
+    this.element.remove()
+  }
+}
+```
+
+### View Usage
+
+```erb
+<%# app/views/notifications/index.html.erb %>
+<div id="notifications">
+  <%= render partial: "notifications/notification",
+    collection: @notifications %>
+</div>
+
+<% if @notifications.next_page %>
+  <div data-controller="fetch-on-visible"
+       data-fetch-on-visible-url-value="<%= notifications_path(page: @notifications.next_page, format: :turbo_stream) %>">
+    <span class="loading-spinner" aria-label="Loading more notifications"></span>
+  </div>
+<% end %>
+```
+
+```ruby
+# app/views/notifications/index.turbo_stream.erb
+<%= turbo_stream.append "notifications" do %>
+  <%= render partial: "notifications/notification",
+    collection: @notifications %>
+<% end %>
+
+<% if @notifications.next_page %>
+  <%= turbo_stream.append "notifications" do %>
+    <div data-controller="fetch-on-visible"
+         data-fetch-on-visible-url-value="<%= notifications_path(page: @notifications.next_page, format: :turbo_stream) %>">
+      <span class="loading-spinner"></span>
+    </div>
+  <% end %>
+<% end %>
+```
+
+---
+
+## Client-Side Notification Grouping (PR #1448)
+
+Group notifications by card on the client side to reduce visual noise:
+
+```javascript
+// app/javascript/controllers/notification_list_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["notification"]
+
+  notificationTargetConnected(element) {
+    this.groupNotifications()
+  }
+
+  groupNotifications() {
+    const grouped = this.groupNotificationsByCardId()
+
+    for (const [cardId, notifications] of Object.entries(grouped)) {
+      if (notifications.length <= 1) continue
+
+      const [primary, ...secondary] = notifications
+
+      primary.classList.add("notification--group-primary")
+      primary.dataset.groupCount = notifications.length
+
+      const badge = primary.querySelector(".notification__group-badge") ||
+        this.createBadge(primary)
+      badge.textContent = `+${secondary.length} more`
+
+      secondary.forEach(el => {
+        el.classList.add("notification--grouped")
+        el.hidden = true
+      })
+    }
+  }
+
+  groupNotificationsByCardId() {
+    const groups = {}
+
+    this.notificationTargets.forEach(el => {
+      const cardId = el.dataset.cardId
+      if (!cardId) return
+
+      groups[cardId] = groups[cardId] || []
+      groups[cardId].push(el)
+    })
+
+    return groups
+  }
+
+  createBadge(element) {
+    const badge = document.createElement("span")
+    badge.className = "notification__group-badge"
+    element.querySelector(".notification__content")?.appendChild(badge)
+    return badge
+  }
+
+  toggle(event) {
+    const cardId = event.currentTarget.dataset.cardId
+    const grouped = this.notificationTargets.filter(
+      el => el.dataset.cardId === cardId && el.classList.contains("notification--grouped")
+    )
+
+    grouped.forEach(el => {
+      el.hidden = !el.hidden
+    })
+  }
+}
+```
+
+---
+
+## RESTful Controller Design (PR #405)
+
+Notification read state as a nested resource - `readings`:
+
+```ruby
+# config/routes.rb
+resources :notifications, only: [:index, :show, :destroy] do
+  resource :reading, only: [:create, :destroy], module: :notifications
+end
+
+namespace :notifications do
+  resource :readings, only: [:create] # bulk read all
+end
+```
+
+```ruby
+# app/controllers/notifications/readings_controller.rb
+class Notifications::ReadingsController < ApplicationController
+  def create
+    notification = current_user.notifications.find(params[:notification_id])
+    notification.mark_as_read
+
+    respond_to do |format|
+      format.html { redirect_back fallback_location: notifications_path }
+      format.turbo_stream
+    end
+  end
+
+  def destroy
+    notification = current_user.notifications.find(params[:notification_id])
+    notification.update!(read_at: nil)
+
+    respond_to do |format|
+      format.html { redirect_back fallback_location: notifications_path }
+      format.turbo_stream
+    end
+  end
+end
+```
+
+```ruby
+# app/controllers/notifications/readings_controller.rb (bulk)
+# Note: separate controller in notifications namespace for bulk operation
+class Notifications::ReadingsController < ApplicationController
+  def create
+    current_user.notifications.read_all
+
+    respond_to do |format|
+      format.html { redirect_to notifications_path, notice: "All marked as read" }
+      format.turbo_stream
+    end
+  end
+end
+```
+
+---
+
+## Email Unsubscribe with Signed Tokens (PR #974)
+
+### generates_token_for
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  generates_token_for :unsubscribe, expires_in: nil do
+    settings.bundle_email_frequency
+  end
+end
+```
+
+The token embeds the current email frequency - if the user changes their preference, old unsubscribe links are automatically invalidated.
+
+### List-Unsubscribe Headers
+
+```ruby
+# app/mailers/notification_mailer.rb
+class NotificationMailer < ApplicationMailer
+  def bundle(user:, notifications:)
+    @user = user
+    @notifications = notifications
+
+    token = user.generate_token_for(:unsubscribe)
+
+    headers["List-Unsubscribe"] = "<#{unsubscribe_url(token: token)}>"
+    headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
+    mail(
+      to: user.email,
+      subject: notification_subject(notifications)
+    )
+  end
+
+  private
+
+  def notification_subject(notifications)
+    if notifications.size == 1
+      notifications.first.summary
+    else
+      "#{notifications.size} new notifications"
+    end
+  end
+end
+```
+
+### UnsubscribesController
+
+```ruby
+# app/controllers/unsubscribes_controller.rb
+class UnsubscribesController < ApplicationController
+  skip_before_action :authenticate
+
+  def show
+    @user = User.find_by_token_for(:unsubscribe, params[:token])
+
+    if @user.nil?
+      redirect_to root_path, alert: "Invalid or expired unsubscribe link"
+    end
+  end
+
+  def create
+    user = User.find_by_token_for!(:unsubscribe, params[:token])
+    user.settings.update!(bundle_email_frequency: :never)
+
+    redirect_to root_path, notice: "You have been unsubscribed from email notifications"
+  end
+end
+```
+
+---
+
+## Email Layout with Inline Styles (PR #974)
+
+### Table Layout for Email Compatibility
+
+```erb
+<%# app/views/layouts/mailer.html.erb %>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 20px 0;">
+        <table width="600" cellpadding="0" cellspacing="0"
+               style="background-color: #ffffff; border-radius: 4px;">
+          <tr>
+            <td style="padding: 24px 32px;">
+              <%= yield %>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 16px 32px; color: #999; font-size: 12px; border-top: 1px solid #eee;">
+              <p>You received this because of your notification settings.</p>
+              <p><%= link_to "Unsubscribe", @unsubscribe_url,
+                style: "color: #999; text-decoration: underline;" %></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+```
+
+### Group by Subject (PR #1574)
+
+```erb
+<%# app/views/notification_mailer/bundle.html.erb %>
+<h2 style="margin: 0 0 16px; font-size: 18px; color: #333;">
+  New notifications
+</h2>
+
+<% @notifications.group_by(&:notifiable).each do |subject, notifications| %>
+  <table width="100%" cellpadding="0" cellspacing="0"
+         style="margin-bottom: 16px; border: 1px solid #eee; border-radius: 4px;">
+    <tr>
+      <td style="padding: 12px 16px; background-color: #f9f9f9; font-weight: bold;">
+        <%= subject.title %>
+      </td>
+    </tr>
+    <% notifications.each do |notification| %>
+      <tr>
+        <td style="padding: 8px 16px; border-top: 1px solid #eee;">
+          <p style="margin: 0;">
+            <strong><%= notification.actor&.name %></strong>
+            <%= notification.action %>
+          </p>
+          <p style="margin: 4px 0 0; color: #999; font-size: 12px;">
+            <%= time_ago_in_words(notification.created_at) %> ago
+          </p>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>
+
+<p style="text-align: center; margin: 24px 0 0;">
+  <%= link_to "View all notifications", notifications_url,
+    style: "display: inline-block; padding: 8px 16px; background-color: #0066cc; color: #fff; text-decoration: none; border-radius: 4px;" %>
+</p>
+```
+
+---
+
+## Testing Notification Delivery (PR #974)
+
+### Time Travel Bundling Test
+
+```ruby
+class Notification::BundleTest < ActiveSupport::TestCase
+  test "bundles notifications within time window" do
+    user = users(:david)
+    user.settings.update!(bundle_email_frequency: :hourly)
+
+    # First notification creates a bundle
+    notification1 = create_notification(user: user)
+    bundle = user.notification_bundles.pending.last
+
+    assert bundle.present?
+    assert_equal "pending", bundle.status
+
+    # Second notification within the hour joins existing bundle
+    travel 30.minutes do
+      notification2 = create_notification(user: user)
+
+      assert_equal 1, user.notification_bundles.pending.count
+      assert_includes bundle.notifications, notification1
+      assert_includes bundle.notifications, notification2
+    end
+
+    # After the window, a new bundle is created
+    travel 2.hours do
+      notification3 = create_notification(user: user)
+
+      assert_equal 2, user.notification_bundles.pending.count
+    end
+  end
+
+  test "delivers bundle with unread notifications" do
+    user = users(:david)
+    user.settings.update!(bundle_email_frequency: :hourly)
+
+    create_notification(user: user)
+    bundle = user.notification_bundles.pending.last
+
+    travel 1.hour do
+      assert_emails 1 do
+        Notification::DeliverAllJob.perform_now
+      end
+
+      assert bundle.reload.delivered?
+    end
+  end
+
+  test "skips bundle when all notifications are read" do
+    user = users(:david)
+    user.settings.update!(bundle_email_frequency: :hourly)
+
+    notification = create_notification(user: user)
+    notification.mark_as_read
+    bundle = user.notification_bundles.pending.last
+
+    travel 1.hour do
+      assert_no_emails do
+        Notification::DeliverAllJob.perform_now
+      end
+
+      assert bundle.reload.skipped?
+    end
+  end
+
+  private
+
+  def create_notification(user:)
+    user.notifications.create!(
+      notifiable: cards(:one),
+      action: "commented on",
+      actor: users(:jason)
+    )
+  end
+end
+```
+
+### Overlap Validation Test
+
+```ruby
+class Notification::BundleValidationTest < ActiveSupport::TestCase
+  test "prevents overlapping pending bundles" do
+    user = users(:david)
+
+    bundle1 = Notification::Bundle.create!(
+      user: user,
+      status: :pending,
+      deliver_after: 1.hour.from_now
+    )
+
+    bundle2 = Notification::Bundle.new(
+      user: user,
+      status: :pending,
+      deliver_after: 30.minutes.from_now
+    )
+
+    assert_not bundle2.valid?
+    assert_includes bundle2.errors[:base], "overlaps with an existing pending bundle"
+  end
+
+  test "allows bundles after previous one is delivered" do
+    user = users(:david)
+
+    bundle1 = Notification::Bundle.create!(
+      user: user,
+      status: :delivered,
+      deliver_after: 1.hour.ago
+    )
+
+    bundle2 = Notification::Bundle.new(
+      user: user,
+      status: :pending,
+      deliver_after: 1.hour.from_now
+    )
+
+    assert bundle2.valid?
+  end
+end
+```
+
+---
+
+## Summary: Architectural Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Read tracking | `read_at` timestamp | Richer than boolean; enables "when read" queries |
+| Bundling | Time-window model | No FK to notifications; flexible aggregation |
+| User preferences | Dedicated Settings model | Single-table per user; enum for frequency |
+| Bundle creation | `after_create` callback | Automatic; transparent to notification creators |
+| Batch delivery | Recurring background job | Multi-tenant aware; every 5 minutes |
+| Real-time UI | Turbo Streams broadcast | Server-pushed updates; no polling |
+| Pagination | Intersection Observer | Infinite scroll without JavaScript frameworks |
+| Client grouping | Stimulus controller | Group by card ID; collapse secondary items |
+| Read/unread API | Nested `readings` resource | RESTful; single and bulk operations |
+| Unsubscribe | `generates_token_for` | Self-invalidating on preference change |
+| Email layout | Inline styles + tables | Maximum email client compatibility |
+| Email grouping | Group by `notifiable` | One section per card/subject |

--- a/compass/observability.md
+++ b/compass/observability.md
@@ -1,0 +1,48 @@
+---
+tags: [rails, 37signals, observability, logging, metrics]
+---
+
+# Observability
+
+> Structured logging, Yabeda metrics, console auditing.
+
+See also: [[configuration]], [[performance]]
+
+---
+
+## Structured JSON Logging
+```ruby
+config.log_level = :fatal
+config.structured_logging.logger = ActiveSupport::Logger.new(STDOUT)
+```
+
+## Multi-Tenant Context
+```ruby
+before_action { logger.struct tenant: ApplicationRecord.current_tenant }
+```
+
+## User Context
+```ruby
+logger.struct "Authorized User##{session.user.id}",
+  authentication: { user: { id: session.user.id } }
+```
+
+## Yabeda Metrics
+```ruby
+gem "yabeda", "yabeda-rails", "yabeda-puma-plugin", "yabeda-prometheus-mmap"
+gem "yabeda-activejob", "yabeda-gc", "yabeda-http_requests", "yabeda-actioncable"
+```
+
+## Silence Health Checks
+```ruby
+config.silence_healthcheck_path = "/up"
+```
+
+## Console Auditing
+```ruby
+gem "console1984"
+gem "audits1984"
+config.console1984.protected_environments = %i[production staging]
+```
+
+## OpenTelemetry Collector as sidecar for container metrics

--- a/compass/performance.md
+++ b/compass/performance.md
@@ -1,0 +1,53 @@
+---
+tags: [rails, 37signals, performance, n-plus-1, puma]
+---
+
+# Performance
+
+> Database, CSS, rendering optimizations.
+
+See also: [[caching]], [[database]], [[hotwire]]
+
+---
+
+## CSS: Avoid complex `:has()` (Safari freezes)
+## Database: N+1 → JOINs, accept SQL when performance requires
+## Pagination: 25-50, "Load more" buttons
+## Debouncing: 100ms on filter search
+## Puma/Ruby:
+```ruby
+workers Concurrent.physical_processor_count
+threads 1, 1
+before_fork { Process.warmup }  # GC, compact, malloc_trim
+```
+Use `autotuner` gem for suggestions.
+
+## N+1 Prevention
+```ruby
+# Bad - extra query
+assignments.exists? assignee: user
+# Good - in-memory
+assignments.any? { |a| a.assignee_id == user.id }
+```
+
+## Preloaded Scopes
+```ruby
+scope :preloaded, -> { includes(:column, :tags, board: [:entropy, :columns]) }
+```
+
+## Active Storage
+- `preprocessed: true` for variants
+- Extend signed URL expiry to 48h (Cloudflare)
+- Skip previews > 16MB
+- Redirect to blob URL for avatars
+
+## Optimistic UI for D&D
+Insert immediately, POST async. Let server re-render.
+
+## Batch SQL Over Loops
+```ruby
+user.mentions
+  .joins("LEFT JOIN cards ON ...")
+  .where("cards.collection_id = ?", id)
+  .destroy_all
+```

--- a/compass/philosophy.md
+++ b/compass/philosophy.md
@@ -1,0 +1,113 @@
+---
+tags: [rails, 37signals, philosophy]
+---
+
+# Development Philosophy
+
+> Core principles observed across 265 PRs in Fizzy.
+
+See also: [[dhh-patterns]], [[jorge-manrubia]], [[jason-zimdars]], [[what-they-avoid]]
+
+---
+
+## Ship, Validate, Refine
+
+- Merge "prototype quality" code to validate with real usage before cleanup
+- Features evolve through iterations (tenanting: 3 attempts before settling)
+- Don't polish prematurely - real-world usage reveals what matters
+
+## Fix Root Causes, Not Symptoms
+
+**Bad**: Add retry logic for race conditions
+**Good**: Use `enqueue_after_transaction_commit` to prevent the race
+
+**Bad**: Work around CSRF issues on cached pages
+**Good**: Don't HTTP cache pages with forms
+
+## Vanilla Rails Over Abstractions
+
+- Thin controllers calling rich domain models
+- No service objects unless truly justified
+- Direct ActiveRecord is fine: `@card.comments.create!(params)`
+- When services exist, they're just POROs: `Signup.new(email:).create_identity`
+
+## When to Extract
+
+- Start in controller, extract when it gets messy
+- Filter logic: controller → model concern → dedicated PORO
+- Don't extract prematurely — wait for pain
+- Rule of three: duplicate twice before abstracting
+
+## Write-Time vs Read-Time Operations
+
+All manipulation should happen when you save, not when you present:
+- Use delegated types for heterogeneous collections needing pagination
+- Pre-compute roll-ups at write time
+- Use `dependent: :delete_all` when no callbacks needed
+- Use counter caches instead of manual counting
+
+```ruby
+# Bad - computing at read time
+def thread_entries
+  (comments + events).sort_by(&:created_at)
+end
+
+# Good - using delegated types with single-table query
+class Message < ApplicationRecord
+  delegated_type :messageable, types: %w[Comment EventSummary]
+end
+bubble.messages.order(:created_at).limit(20)
+```
+
+## Common Review Themes
+
+- **Naming**: Use positive names (`active` not `not_deleted`, `unpopped`)
+- **DB over AR**: Prefer database constraints over ActiveRecord validations
+- **Migrations**: Use SQL, avoid model references that break future runs
+- **Simplify**: Links over JavaScript when browser affordances suffice
+
+## StringInquirer for Action Predicates
+
+```ruby
+def action
+  self[:action].inquiry
+end
+# Usage: event.action.completed?
+```
+
+## Caching Constraints Inform Architecture
+
+Design caching early — it reveals architectural issues:
+- Can't use `Current.user` in cached partials
+- Solution: Push user-specific logic to Stimulus controllers reading from meta tags
+- Leave FIXME comments when you discover caching conflicts
+
+## Rails Patterns
+
+### Delegated Types for Polymorphism
+```ruby
+class Message < ApplicationRecord
+  delegated_type :messageable, types: %w[Comment EventSummary],
+                 inverse_of: :message, dependent: :destroy
+end
+```
+
+### Store Accessor for JSON Columns
+```ruby
+store_accessor :filters, :order_by, :status, :assignee_ids
+validates :order_by, inclusion: { in: ORDERS.keys, allow_nil: true }
+```
+
+### Normalizes for Data Consistency (Rails 7.1+)
+```ruby
+normalizes :subscribed_actions,
+  with: ->(value) { Array.wrap(value).map(&:to_s).uniq & PERMITTED_ACTIONS }
+```
+
+### params.expect (Rails 7.1+)
+```ruby
+# Before
+params.require(:user).permit(:name, :email)
+# After
+params.expect(user: [:name, :email])
+```

--- a/compass/routing.md
+++ b/compass/routing.md
@@ -1,0 +1,213 @@
+---
+tags: [compass, rails, routing, rest, crud]
+---
+
+# Routing Patterns
+
+> Everything is CRUD - resource-based routing over custom actions.
+
+See also: [[controllers]], [[models]]
+
+---
+
+## The CRUD Principle
+
+Every action maps to a CRUD verb. When something doesn't fit, **create a new resource**.
+
+```ruby
+# BAD: Custom actions on existing resource
+resources :cards do
+  post :close
+  post :reopen
+  post :archive
+  post :gild
+end
+
+# GOOD: New resources for each state change
+resources :cards do
+  resource :closure      # POST to close, DELETE to reopen
+  resource :goldness     # POST to gild, DELETE to ungild
+  resource :not_now      # POST to postpone
+  resource :pin          # POST to pin, DELETE to unpin
+  resource :watch        # POST to watch, DELETE to unwatch
+end
+```
+
+## Real Examples from Fizzy Routes
+
+```ruby
+resources :cards do
+  scope module: :cards do
+    resource :board
+    resource :closure
+    resource :column
+    resource :goldness
+    resource :image
+    resource :not_now
+    resource :pin
+    resource :publish
+    resource :reading
+    resource :triage
+    resource :watch
+
+    resources :assignments
+    resources :steps
+    resources :taggings
+    resources :comments do
+      resources :reactions
+    end
+  end
+end
+```
+
+## Noun-Based Resources
+
+Turn verbs into nouns:
+
+| Action | Resource |
+|--------|----------|
+| Close a card | `card.closure` |
+| Watch a board | `board.watching` |
+| Pin an item | `item.pin` |
+| Publish a board | `board.publication` |
+| Assign a user | `card.assignment` |
+| Mark as golden | `card.goldness` |
+| Postpone | `card.not_now` |
+
+## Namespace for Context
+
+```ruby
+resources :boards do
+  scope module: :boards do
+    resource :publication
+    resource :entropy
+    resource :involvement
+
+    namespace :columns do
+      resource :not_now
+      resource :stream
+      resource :closed
+    end
+  end
+end
+```
+
+## Use `resolve` for Custom URL Generation
+
+```ruby
+resolve "Comment" do |comment, options|
+  options[:anchor] = ActionView::RecordIdentifier.dom_id(comment)
+  route_for :card, comment.card, options
+end
+
+resolve "Notification" do |notification, options|
+  polymorphic_url(notification.notifiable_target, options)
+end
+```
+
+## Shallow Nesting
+
+```ruby
+resources :boards, shallow: true do
+  resources :cards
+end
+# /boards/:board_id/cards      (index, new, create)
+# /cards/:id                   (show, edit, update, destroy)
+```
+
+## Singular Resources
+
+Use `resource` (singular) for one-per-parent resources:
+
+```ruby
+resources :cards do
+  resource :closure
+  resource :watching
+  resource :goldness
+end
+```
+
+## Module Scoping
+
+```ruby
+# scope module (no URL prefix)
+resources :cards do
+  scope module: :cards do
+    resource :closure      # Cards::ClosuresController at /cards/:id/closure
+  end
+end
+
+# namespace (adds URL prefix)
+namespace :cards do
+  resources :drops         # Cards::DropsController at /cards/drops
+end
+```
+
+## Path-Based Multi-Tenancy
+
+```ruby
+scope "/:account_id" do
+  resources :boards
+  resources :cards
+end
+```
+
+## Controller Mapping
+
+```
+app/controllers/
+├── application_controller.rb
+├── cards_controller.rb
+├── cards/
+│   ├── assignments_controller.rb
+│   ├── closures_controller.rb
+│   ├── columns_controller.rb
+│   ├── drops_controller.rb
+│   ├── goldnesses_controller.rb
+│   ├── not_nows_controller.rb
+│   ├── pins_controller.rb
+│   ├── watches_controller.rb
+│   └── comments/
+│       └── reactions_controller.rb
+├── boards_controller.rb
+└── boards/
+    ├── columns_controller.rb
+    ├── entropies_controller.rb
+    └── publications_controller.rb
+```
+
+## API Design: Same Controllers, Different Format
+
+No separate API namespace - just `respond_to`:
+
+```ruby
+class Cards::ClosuresController < ApplicationController
+  include CardScoped
+
+  def create
+    @card.close
+    respond_to do |format|
+      format.turbo_stream { render_card_replacement }
+      format.json { head :no_content }
+    end
+  end
+end
+```
+
+### Consistent Response Codes
+
+| Action | Success Code |
+|--------|--------------|
+| Create | `201 Created` + `Location` header |
+| Update | `204 No Content` |
+| Delete | `204 No Content` |
+
+## Key Principles
+
+1. **Every action is CRUD** - Create, read, update, or destroy something
+2. **Verbs become nouns** - "close" becomes "closure" resource
+3. **Shallow nesting** - Avoid deep URL nesting
+4. **Singular when appropriate** - `resource` for one-per-parent
+5. **Namespace for grouping** - Related controllers together
+6. **Use `resolve`** - For polymorphic URL generation
+7. **Same controller, different format** - No separate API controllers

--- a/compass/security.md
+++ b/compass/security.md
@@ -1,0 +1,61 @@
+---
+tags: [rails, 37signals, security, csrf, xss, ssrf]
+---
+
+# Security Checklist
+
+> XSS, CSRF, SSRF, CSP, rate limiting.
+
+See also: [[authentication]], [[webhooks]], [[multi-tenancy]]
+
+---
+
+## XSS: Always escape before `html_safe`
+```ruby
+"<span>#{h(user_input)}</span>".html_safe
+```
+
+## CSRF
+- Don't HTTP cache pages with forms
+- Sec-Fetch-Site header as additional check:
+```ruby
+def safe_fetch_site?
+  %w[same-origin same-site].include?(request.headers["Sec-Fetch-Site"]&.downcase)
+end
+```
+
+## SSRF (for [[webhooks]])
+- DNS pinning: resolve once, use pinned IP
+- Block private networks (127.0.0.0/8, 10.0.0.0/8, 169.254.0.0/16)
+- Validate at creation AND request time
+
+## Content Security Policy
+```ruby
+config.content_security_policy do |policy|
+  policy.script_src :self
+  policy.base_uri :none
+  policy.frame_ancestors :self
+end
+```
+Nonce-based script loading for importmap.
+
+## Rate Limiting (Rails 7.2+)
+```ruby
+rate_limit to: 10, within: 15.minutes, only: :create
+```
+
+## Authorization
+```ruby
+before_action :ensure_can_administer
+def ensure_can_administer
+  head :forbidden unless Current.user.admin?
+end
+```
+
+## Multi-Tenancy Security
+- Scope broadcasts by account
+- Disconnect deactivated users via `remote_connections`
+- Scope all queries through `Current.account`
+
+## Action Text Sanitizer
+Sync allowed tags in `after_initialize` — production eager loading bypasses config.

--- a/compass/stimulus.md
+++ b/compass/stimulus.md
@@ -1,0 +1,111 @@
+---
+tags: [rails, 37signals, stimulus, javascript]
+---
+
+# Stimulus Controllers
+
+> 52 controllers, ~60/40 reusable/domain-specific. Single-purpose, configured via values/classes, event-based communication.
+
+See also: [[hotwire]], [[accessibility]], [[views]]
+
+---
+
+## Reusable Controllers Catalog
+
+### Copy-to-Clipboard (25 lines)
+```javascript
+export default class extends Controller {
+  static values = { content: String }
+  static classes = [ "success" ]
+  async copy(event) {
+    event.preventDefault()
+    this.reset()
+    try {
+      await navigator.clipboard.writeText(this.contentValue)
+      this.element.classList.add(this.successClass)
+    } catch {}
+  }
+  reset() {
+    this.element.classList.remove(this.successClass)
+    this.element.offsetWidth // Force reflow
+  }
+}
+```
+
+### Auto-Submit (28 lines)
+```javascript
+export default class extends Controller {
+  static values = { delay: { type: Number, default: 300 } }
+  submit() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => this.element.requestSubmit(), this.delayValue)
+  }
+  submitNow() {
+    clearTimeout(this.timeout)
+    this.element.requestSubmit()
+  }
+  disconnect() { clearTimeout(this.timeout) }
+}
+```
+
+### Dialog (native `<dialog>`)
+```javascript
+export default class extends Controller {
+  open() { this.element.showModal() }
+  close() { this.element.close() }
+  closeOnOutsideClick(event) {
+    if (event.target === this.element) this.close()
+  }
+}
+```
+
+### Other Reusable Controllers
+- **Auto-Click** (7 lines) — clicks element on connect
+- **Element Removal** (7 lines) — removes element on action
+- **Toggle Class** (31 lines) — toggle/add/remove CSS classes
+- **Auto-Resize** (32 lines) — auto-expands textareas
+- **Local Time** (40 lines) — user's local timezone
+- **Beacon** (20 lines) — `navigator.sendBeacon` for tracking
+- **Form Reset** (12 lines) — reset on successful submit
+- **Character Counter** (25 lines) — remaining chars display
+
+## Best Practices
+
+### Use Values API
+```javascript
+static values = { url: String, delay: Number }
+this.urlValue  // not this.element.getAttribute("data-url")
+```
+
+### Always Clean Up in `disconnect()`
+```javascript
+disconnect() {
+  clearTimeout(this.timeout)
+  this.observer?.disconnect()
+  this.element.removeEventListener("custom", this.handler)
+}
+```
+
+### Use `:self` Action Filter
+```javascript
+// Only trigger on this element, not bubbled events
+data-action="click:self->modal#close"
+```
+
+### Dispatch Events for Communication
+```javascript
+this.dispatch("selected", { detail: { id: this.idValue } })
+// data-action="dropdown:selected->form#updateField"
+```
+
+### Extract Shared Helpers
+```javascript
+// app/javascript/helpers/timing_helpers.js
+export function debounce(fn, delay = 1000) {
+  let timeoutId = null
+  return (...args) => {
+    clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => fn.apply(this, args), delay)
+  }
+}
+```

--- a/compass/testing.md
+++ b/compass/testing.md
@@ -1,0 +1,463 @@
+---
+tags: [compass, rails, testing, minitest, fixtures]
+---
+
+# Testing
+
+See also: [[models]], [[controllers]]
+
+## Minitest Over RSpec
+
+37signals uses Minitest, not RSpec. Why:
+
+- **Simpler.** Minitest is plain Ruby. Tests are methods, assertions are method calls. No DSL to learn, no magic matchers, no `subject`/`let`/`described_class` indirection.
+- **Ships with Rails.** No extra gem, no configuration, no version conflicts. `rails new` gives you a working test suite.
+- **Faster boot.** Minitest loads faster than RSpec. On a large app with thousands of tests, this matters.
+- **Less ceremony.** A Minitest test is a method that starts with `test_`. An assertion is `assert_equal expected, actual`. That's it.
+
+```ruby
+# Minitest — plain Ruby, obvious, fast
+class ProjectTest < ActiveSupport::TestCase
+  test "requires a name" do
+    project = Project.new(name: nil)
+    assert_not project.valid?
+    assert_includes project.errors[:name], "can't be blank"
+  end
+end
+
+# vs RSpec — DSL on top of DSL
+RSpec.describe Project do
+  describe "validations" do
+    it "requires a name" do
+      project = Project.new(name: nil)
+      expect(project).not_to be_valid
+      expect(project.errors[:name]).to include("can't be blank")
+    end
+  end
+end
+```
+
+The Minitest version is shorter, clearer, and requires knowing less API.
+
+## Fixtures Over Factories
+
+Fixtures are loaded once into the database at the start of the test suite. They stay there for all tests, wrapped in transactions that roll back after each test.
+
+Why fixtures over factories (FactoryBot):
+
+- **Loaded once.** Fixtures are inserted once, not per-test. This is dramatically faster than creating objects in every test.
+- **Deterministic IDs.** Fixture records have stable, predictable IDs derived from their label names. You can reference them reliably.
+- **Encourage realistic data.** Fixtures represent your actual data model with all its relationships. Factories encourage creating minimal, disconnected objects.
+- **No N+1 creation.** Factories with associations create entire object graphs per test. Fixtures share one graph.
+
+```yaml
+# test/fixtures/accounts.yml
+basecamp:
+  name: Basecamp
+
+hey:
+  name: HEY
+```
+
+```yaml
+# test/fixtures/projects.yml
+website_redesign:
+  account: basecamp
+  name: Website Redesign
+  description: Redesign the marketing site
+
+mobile_app:
+  account: basecamp
+  name: Mobile App
+  description: Build the iOS app
+```
+
+## Fixture Relationships
+
+Reference related fixtures by label name, not by ID:
+
+```yaml
+# test/fixtures/tasks.yml
+design_homepage:
+  project: website_redesign    # references projects(:website_redesign)
+  title: Design homepage
+  position: 1
+
+build_navigation:
+  project: website_redesign
+  title: Build navigation
+  position: 2
+
+setup_ci:
+  project: mobile_app
+  title: Set up CI pipeline
+  position: 1
+```
+
+Rails resolves the label to the fixture's ID automatically. Never hardcode IDs in fixtures — they're generated from the label hash and will differ across environments.
+
+## ERB in Fixtures
+
+Use ERB for dynamic values in fixtures:
+
+```yaml
+# test/fixtures/magic_links.yml
+valid_link:
+  identity: pedro
+  code: "123456"
+  created_at: <%= Time.current %>
+  claimed_at:
+
+expired_link:
+  identity: pedro
+  code: "654321"
+  created_at: <%= 1.hour.ago %>
+  claimed_at:
+
+claimed_link:
+  identity: pedro
+  code: "111111"
+  created_at: <%= 5.minutes.ago %>
+  claimed_at: <%= 1.minute.ago %>
+```
+
+ERB is evaluated when fixtures are loaded. This is useful for time-sensitive records (magic links, tokens, subscriptions) that need relative timestamps.
+
+## Test Structure
+
+Follow a consistent structure: setup, action, assertion.
+
+```ruby
+class ProjectTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:basecamp)
+    @project = projects(:website_redesign)
+  end
+
+  test "creates a project with tasks" do
+    assert_difference -> { Project.count } => 1, -> { Task.count } => 2 do
+      project = @account.projects.create!(
+        name: "New Project",
+        tasks_attributes: [
+          { title: "First task", position: 1 },
+          { title: "Second task", position: 2 }
+        ]
+      )
+
+      assert_equal "New Project", project.name
+      assert_equal 2, project.tasks.count
+      assert_equal @account, project.account
+    end
+  end
+
+  test "requires a name" do
+    project = @account.projects.build(name: "")
+    assert_not project.valid?
+    assert_includes project.errors[:name], "can't be blank"
+  end
+
+  test "scopes to account" do
+    assert_includes @account.projects, @project
+    assert_not_includes accounts(:hey).projects, @project
+  end
+end
+```
+
+`assert_difference` takes a hash of lambdas to counts, verifying that all counts change as expected within the block. This catches accidental side effects (creating too many records, missing cascades).
+
+## Integration Tests
+
+Integration tests (request tests) exercise the full stack from HTTP request to response:
+
+```ruby
+class ProjectsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:basecamp)
+    @project = projects(:website_redesign)
+    sign_in_as identities(:pedro)
+  end
+
+  test "shows a project" do
+    get account_project_url(@account, @project)
+
+    assert_response :success
+    assert_select "h1", @project.name
+  end
+
+  test "creates a project" do
+    assert_difference "Project.count", 1 do
+      post account_projects_url(@account), params: {
+        project: { name: "New Project", description: "A new project" }
+      }
+    end
+
+    assert_redirected_to account_project_url(@account, Project.last)
+    follow_redirect!
+    assert_select "h1", "New Project"
+  end
+
+  test "requires authentication" do
+    sign_out
+
+    get account_project_url(@account, @project)
+    assert_redirected_to new_session_url
+  end
+
+  test "returns not found for other accounts" do
+    other_project = projects(:hey_email)
+
+    assert_raises ActiveRecord::RecordNotFound do
+      get account_project_url(@account, other_project)
+    end
+  end
+end
+```
+
+Note the `sign_in_as` helper (covered below). Integration tests should cover the happy path, authentication, authorization, and error cases.
+
+## System Tests
+
+System tests use Capybara to drive a real browser. Use them for complex UI interactions that can't be tested with integration tests:
+
+```ruby
+class ProjectBoardTest < ApplicationSystemTestCase
+  setup do
+    sign_in_as identities(:pedro)
+    @account = accounts(:basecamp)
+    @project = projects(:website_redesign)
+  end
+
+  test "reorders tasks by dragging" do
+    visit account_project_url(@account, @project)
+
+    first_task = find("[data-task-id='#{tasks(:design_homepage).id}']")
+    second_task = find("[data-task-id='#{tasks(:build_navigation).id}']")
+
+    # Drag first task below second task
+    first_task.drag_to(second_task)
+
+    # Verify new order persisted
+    visit account_project_url(@account, @project)
+
+    task_elements = all("[data-task-id]")
+    assert_equal tasks(:build_navigation).id.to_s, task_elements[0]["data-task-id"]
+    assert_equal tasks(:design_homepage).id.to_s, task_elements[1]["data-task-id"]
+  end
+
+  test "creates a task inline" do
+    visit account_project_url(@account, @project)
+
+    click_on "Add task"
+    fill_in "Title", with: "New task from system test"
+    click_on "Save"
+
+    assert_text "New task from system test"
+  end
+end
+```
+
+System tests are slow. Use them sparingly — only for interactions that require JavaScript, drag-and-drop, or multi-step UI flows.
+
+## Test Helpers
+
+### SignInHelper
+
+```ruby
+# test/test_helpers/sign_in_helper.rb
+module SignInHelper
+  def sign_in_as(identity)
+    session = identity.sessions.create!
+    post session_url, params: { token: session.token }
+
+    # For integration tests, set the cookie directly
+    cookies[:session_token] = session.token
+  end
+
+  def sign_out
+    delete session_url
+  end
+end
+
+# test/test_helper.rb
+class ActionDispatch::IntegrationTest
+  include SignInHelper
+end
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include SignInHelper
+end
+```
+
+### Parallelize and Fixtures
+
+```ruby
+# test/test_helper.rb
+class ActiveSupport::TestCase
+  # Run tests in parallel with threads
+  parallelize(workers: :number_of_processors)
+
+  # Load all fixtures — don't cherry-pick
+  fixtures :all
+
+  # Add more helper methods here...
+end
+```
+
+Always use `fixtures :all`. Cherry-picking fixtures (`fixtures :users, :projects`) leads to mysterious failures when a fixture references another fixture that isn't loaded. Load everything — it's fast because they're only inserted once.
+
+## Testing Time
+
+Use `travel_to` for tests that depend on the current time:
+
+```ruby
+class MagicLinkTest < ActiveSupport::TestCase
+  test "expires after 15 minutes" do
+    magic_link = magic_links(:valid_link)
+
+    travel_to 14.minutes.from_now do
+      assert_not magic_link.expired?
+    end
+
+    travel_to 16.minutes.from_now do
+      assert magic_link.expired?
+    end
+  end
+
+  test "unclaimed scope excludes expired links" do
+    travel_to 20.minutes.from_now do
+      assert_empty MagicLink.unclaimed
+    end
+  end
+end
+```
+
+`travel_to` stubs `Time.current`, `Date.current`, and `DateTime.current` within the block, then restores them. Always use a block form to ensure time is restored even if the test fails.
+
+## VCR for External APIs
+
+Use VCR to record and replay HTTP interactions with external APIs:
+
+```ruby
+# test/test_helper.rb
+VCR.configure do |config|
+  config.cassette_library_dir = "test/cassettes"
+  config.hook_into :webmock
+  config.default_cassette_options = { record: :once }
+  config.filter_sensitive_data("<STRIPE_KEY>") { Rails.application.credentials.dig(:stripe, :api_key) }
+end
+```
+
+```ruby
+class StripeChargeTest < ActiveSupport::TestCase
+  test "creates a charge" do
+    VCR.use_cassette("stripe/create_charge") do
+      charge = StripeService.charge(
+        amount: 1000,
+        currency: "usd",
+        source: "tok_visa"
+      )
+
+      assert charge.paid
+      assert_equal 1000, charge.amount
+    end
+  end
+end
+```
+
+VCR records the HTTP interaction on first run, then replays it on subsequent runs. This makes tests fast, deterministic, and runnable offline. Use `filter_sensitive_data` to scrub API keys from cassettes before committing them.
+
+## Testing Jobs
+
+### assert_enqueued_with
+
+Test that a job is enqueued with the correct arguments:
+
+```ruby
+class ProjectNotificationTest < ActiveSupport::TestCase
+  test "enqueues notification job on create" do
+    assert_enqueued_with(job: NotifyMembersJob) do
+      accounts(:basecamp).projects.create!(name: "New Project")
+    end
+  end
+
+  test "enqueues with correct arguments" do
+    project = accounts(:basecamp).projects.create!(name: "New Project")
+
+    assert_enqueued_with(
+      job: NotifyMembersJob,
+      args: [project],
+      queue: "default"
+    ) do
+      project.notify_members!
+    end
+  end
+end
+```
+
+### perform_enqueued_jobs
+
+Run enqueued jobs inline to test the full chain:
+
+```ruby
+class ProjectLifecycleTest < ActiveSupport::TestCase
+  test "sends welcome email when project is created" do
+    perform_enqueued_jobs do
+      project = accounts(:basecamp).projects.create!(name: "New Project")
+
+      assert_equal 1, ActionMailer::Base.deliveries.size
+      email = ActionMailer::Base.deliveries.last
+      assert_equal "New project created: New Project", email.subject
+    end
+  end
+end
+```
+
+### assert_emails
+
+Test email sending directly:
+
+```ruby
+class MagicLinkMailerTest < ActionMailer::TestCase
+  test "sends sign-in email with code in subject" do
+    identity = identities(:pedro)
+    magic_link = identity.magic_links.create!
+
+    assert_emails 1 do
+      MagicLinkMailer.with(identity: identity, magic_link: magic_link).sign_in.deliver_now
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal [identity.email], email.to
+    assert_includes email.subject, magic_link.code
+  end
+end
+```
+
+## When Tests Ship
+
+Tests ship with features, in the same commit. There is no "add tests later" — if the feature isn't tested, it isn't done.
+
+```
+# A feature commit includes:
+app/models/task.rb              # the model
+app/controllers/tasks_controller.rb  # the controller
+app/views/tasks/                # the views
+test/models/task_test.rb        # model tests
+test/controllers/tasks_controller_test.rb  # integration tests
+test/system/tasks_test.rb       # system tests (if needed)
+test/fixtures/tasks.yml         # fixture data
+```
+
+Every pull request includes tests. CI runs the full suite. A PR with failing tests does not merge.
+
+## Key Principles
+
+1. **Minitest, not RSpec.** Use what ships with Rails. It's simpler, faster, and has no learning curve beyond plain Ruby.
+
+2. **Fixtures, not factories.** Load once, reference by label, share across all tests. Factories are slower and encourage unrealistic data.
+
+3. **Test the behavior, not the implementation.** Assert what the user sees (responses, redirects, rendered content) not internal state. Test public interfaces, not private methods.
+
+4. **Tests ship with features.** Same commit, same PR. No test debt. If it isn't tested, it isn't done.
+
+5. **Keep tests fast.** Parallelize. Use fixtures (loaded once). Avoid system tests when integration tests suffice. Mock external APIs with VCR. A fast test suite gets run constantly; a slow one gets ignored.

--- a/compass/views.md
+++ b/compass/views.md
@@ -1,0 +1,259 @@
+---
+tags: [compass, rails, views, turbo, partials]
+---
+
+# Views
+
+> Turbo Streams, partials over components, and server-rendered HTML.
+
+See also: [[controllers]], [[hotwire]], [[stimulus]], [[caching]]
+
+---
+
+## Turbo Streams for Partial Updates
+
+```erb
+<%# app/views/cards/comments/create.turbo_stream.erb %>
+<%= turbo_stream.before [@card, :new_comment],
+    partial: "cards/comments/comment",
+    locals: { comment: @comment } %>
+
+<%= turbo_stream.update [@card, :new_comment],
+    partial: "cards/comments/new",
+    locals: { card: @card } %>
+```
+
+## Morphing for Complex Updates
+
+```erb
+<%= turbo_stream.replace dom_id(@card, :card_container),
+    partial: "cards/container",
+    method: :morph,
+    locals: { card: @card.reload } %>
+```
+
+## Turbo Stream Subscriptions in Views
+
+```erb
+<%= turbo_stream_from @card %>
+<%= turbo_stream_from @card, :activity %>
+
+<div data-controller="beacon" data-beacon-url-value="<%= card_reading_path(@card) %>">
+  <%= render "cards/container", card: @card %>
+  <%= render "cards/messages", card: @card %>
+</div>
+```
+
+---
+
+## Partials Over ViewComponents
+
+```erb
+<%= render "cards/container", card: @card %>
+<%= render "cards/display/perma/meta", card: @card %>
+
+<% cache card do %>
+  <section id="<%= dom_id(card, :card_container) %>">
+    <%= render "cards/container/content", card: card %>
+  </section>
+<% end %>
+```
+
+---
+
+## Fragment Caching Patterns
+
+### Basic Fragment Cache
+
+```erb
+<% cache card do %>
+  <%= render "cards/preview", card: card %>
+<% end %>
+```
+
+### Composite Cache Keys
+
+```erb
+<% cache [card, Current.user, timezone_from_cookie] do %>
+  <%= render "cards/preview", card: card %>
+<% end %>
+```
+
+### Collection Caching
+
+```erb
+<%= render partial: "cards/preview",
+           collection: @cards,
+           cached: true %>
+```
+
+### Cache with Touch Chains
+
+```ruby
+class Comment < ApplicationRecord
+  belongs_to :card, touch: true
+end
+
+class Card < ApplicationRecord
+  belongs_to :board, touch: true
+end
+```
+
+---
+
+## View Helpers: Stimulus-Integrated Components
+
+### Dialog Helper
+
+```ruby
+module DialogHelper
+  def dialog_tag(id, **options, &block)
+    options[:data] ||= {}
+    options[:data][:controller] = "dialog #{options.dig(:data, :controller)}".strip
+    options[:data][:action] = "click->dialog#closeOnOutsideClick keydown.esc->dialog#close"
+    tag.dialog(id: id, **options, &block)
+  end
+
+  def dialog_close_button(**options)
+    options[:data] ||= {}
+    options[:data][:action] = "dialog#close"
+    tag.button("Close", **options)
+  end
+end
+```
+
+### Auto-Submit Form Helper
+
+```ruby
+module FormHelper
+  def auto_submit_form_with(**options, &block)
+    options[:data] ||= {}
+    options[:data][:controller] = "auto-submit #{options.dig(:data, :controller)}".strip
+    options[:data][:auto_submit_delay_value] = options.delete(:delay) || 300
+    form_with(**options, &block)
+  end
+end
+```
+
+### Button Helpers
+
+```ruby
+module ButtonHelper
+  def copy_button(content:, **options)
+    options[:data] ||= {}
+    options[:data][:controller] = "copy-to-clipboard"
+    options[:data][:copy_to_clipboard_content_value] = content
+    options[:data][:action] = "click->copy-to-clipboard#copy"
+    tag.button("Copy", **options)
+  end
+end
+```
+
+---
+
+## HTTP Caching in Views
+
+```ruby
+def show
+  @card = Card.find(params[:id])
+  fresh_when etag: [@card, Current.user, timezone_from_cookie]
+end
+
+def index
+  @cards = Card.recent
+  fresh_when etag: @cards
+end
+```
+
+---
+
+## Turbo Frame Patterns
+
+### Lazy Loading Frames
+
+```erb
+<%= turbo_frame_tag "notifications",
+    src: notifications_path,
+    loading: :lazy do %>
+  <p>Loading notifications...</p>
+<% end %>
+```
+
+### Frame for Inline Editing
+
+```erb
+<%= turbo_frame_tag dom_id(card, :title) do %>
+  <h1><%= card.title %></h1>
+  <%= link_to "Edit", edit_card_path(card) %>
+<% end %>
+```
+
+### Frame-Targeted Forms
+
+```erb
+<%= turbo_frame_tag dom_id(@card, :edit) do %>
+  <%= form_with model: @card do |f| %>
+    <%= f.text_field :title %>
+    <%= f.submit %>
+  <% end %>
+<% end %>
+```
+
+---
+
+## Broadcast Patterns
+
+### Model-Level Broadcasting
+
+```ruby
+class Comment < ApplicationRecord
+  after_create_commit -> {
+    broadcast_append_to card, target: "comments"
+  }
+
+  after_destroy_commit -> {
+    broadcast_remove_to card
+  }
+end
+```
+
+### Scoped Broadcasting (Multi-Tenant)
+
+```ruby
+broadcast_to [Current.account, card], target: "comments"
+```
+
+---
+
+## Rendering Conventions
+
+### Prefer Locals Over Instance Variables
+
+```erb
+<%# Good - explicit dependencies %>
+<%= render "cards/preview", card: card, draggable: true %>
+
+<%# Avoid - implicit dependencies %>
+<%= render "cards/preview" %>
+```
+
+### Partial Naming
+
+```
+app/views/
+├── cards/
+│   ├── _card.html.erb
+│   ├── _preview.html.erb
+│   ├── _container.html.erb
+│   ├── _form.html.erb
+│   └── container/
+│       └── _content.html.erb
+```
+
+### DOM ID Conventions
+
+```erb
+<div id="<%= dom_id(card) %>">           <%# card_123 %>
+<div id="<%= dom_id(card, :preview) %>"> <%# preview_card_123 %>
+<div id="<%= dom_id(card, :comments) %>"> <%# comments_card_123 %>
+```

--- a/compass/watching.md
+++ b/compass/watching.md
@@ -1,0 +1,44 @@
+---
+tags: [rails, 37signals, watching, subscriptions]
+---
+
+# Watching
+
+> Involvement enum on access records, not separate subscriptions.
+
+See also: [[notifications]], [[actioncable]], [[models]]
+
+---
+
+## Embed in Access Records
+```ruby
+class Access < ApplicationRecord
+  enum :involvement, %i[ access_only watching ]
+end
+```
+No separate `Subscription` model.
+
+## Binary is Best
+"Watching" vs "Not Watching" — clearer than 3+ levels.
+
+## Collection vs Resource Watching
+- **Collection** (boards): notify of NEW items
+- **Resource** (cards): notify of UPDATES to this item
+
+```ruby
+module Card::Watchable
+  included do
+    has_many :watches, dependent: :destroy
+    has_many :watchers, -> { active.merge(Watch.watching) }, through: :watches, source: :user
+    after_create -> { watch_by creator }
+  end
+end
+```
+
+## Clean Up on Access Removal
+When access revoked, destroy watches, notifications, mentions.
+
+## Toggle UI with Turbo Streams
+Update multiple parts in one response (button + watchers list).
+
+## Always Notify for @mentions and assignments regardless of involvement level.

--- a/compass/webhooks.md
+++ b/compass/webhooks.md
@@ -1,0 +1,639 @@
+---
+tags: [compass, rails, webhooks, security]
+see-also:
+  - "[[security]]"
+  - "[[background-jobs]]"
+---
+
+# Webhooks
+
+## SSRF Protection (PR #1196)
+
+Server-Side Request Forgery protection prevents webhooks from hitting internal services:
+
+```ruby
+# app/models/concerns/ssrf_protection.rb
+module SsrfProtection
+  extend ActiveSupport::Concern
+
+  DISALLOWED_IP_RANGES = [
+    IPAddr.new("0.0.0.0/8"),        # Current network
+    IPAddr.new("10.0.0.0/8"),       # Private A
+    IPAddr.new("100.64.0.0/10"),    # Shared address space
+    IPAddr.new("127.0.0.0/8"),      # Loopback
+    IPAddr.new("169.254.0.0/16"),   # Link-local
+    IPAddr.new("172.16.0.0/12"),    # Private B
+    IPAddr.new("192.0.0.0/24"),     # IETF protocol assignments
+    IPAddr.new("192.168.0.0/16"),   # Private C
+    IPAddr.new("::1/128"),          # IPv6 loopback
+    IPAddr.new("fc00::/7"),         # IPv6 unique local
+    IPAddr.new("fe80::/10"),        # IPv6 link-local
+  ].freeze
+
+  def resolve_ip(hostname)
+    Resolv.getaddress(hostname)
+  rescue Resolv::ResolvError
+    raise SsrfProtection::DnsResolutionError, "Could not resolve hostname: #{hostname}"
+  end
+
+  def validate_ip!(ip_string)
+    ip = IPAddr.new(ip_string)
+
+    if private_address?(ip)
+      raise SsrfProtection::PrivateAddressError,
+        "Requests to private/internal addresses are not allowed: #{ip_string}"
+    end
+
+    ip_string
+  end
+
+  def private_address?(ip)
+    DISALLOWED_IP_RANGES.any? { |range| range.include?(ip) }
+  end
+
+  # IP pinning: resolve DNS once and pin to that IP for the request
+  # Prevents DNS rebinding attacks
+  def perform_safe_request(url, **options)
+    uri = URI.parse(url)
+    resolved_ip = resolve_ip(uri.host)
+    validate_ip!(resolved_ip)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    http.open_timeout = 5
+    http.read_timeout = 10
+    http.ipaddr = resolved_ip  # Pin to resolved IP
+
+    request = build_request(uri, **options)
+    http.request(request)
+  end
+
+  class DnsResolutionError < StandardError; end
+  class PrivateAddressError < StandardError; end
+end
+```
+
+---
+
+## Delivery Pattern: Asynchronous with State Machine (PR #1196)
+
+```ruby
+# app/models/webhook/delivery.rb
+class Webhook::Delivery < ApplicationRecord
+  include SsrfProtection
+
+  belongs_to :webhook
+  belongs_to :deliverable, polymorphic: true
+
+  enum :status, {
+    pending: 0,
+    delivered: 1,
+    failed: 2,
+    timed_out: 3,
+    error: 4
+  }
+
+  store :request, accessors: %i[
+    request_url request_headers request_body
+  ], coder: JSON
+
+  store :response, accessors: %i[
+    response_code response_headers response_body
+  ], coder: JSON
+
+  scope :triggered_by, ->(event) { where(event: event) }
+
+  MAX_RESPONSE_SIZE = 50.kilobytes
+
+  def perform_request
+    result = perform_safe_request(
+      webhook.url,
+      method: :post,
+      headers: signed_headers,
+      body: payload
+    )
+
+    self.response_code = result.code.to_i
+    self.response_headers = result.each_header.to_h
+    self.response_body = result.body&.truncate(MAX_RESPONSE_SIZE)
+    self.status = result.code.to_i.in?(200..299) ? :delivered : :failed
+
+    save!
+  rescue Net::OpenTimeout, Net::ReadTimeout => e
+    update!(status: :timed_out, response_body: e.message)
+  rescue SsrfProtection::PrivateAddressError, SsrfProtection::DnsResolutionError => e
+    update!(status: :error, response_body: e.message)
+  rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+    update!(status: :error, response_body: e.message)
+  rescue StandardError => e
+    update!(status: :error, response_body: "Unexpected error: #{e.message}")
+  end
+end
+```
+
+---
+
+## Retry Strategy: Delinquency Tracking (PR #1196)
+
+Instead of exponential backoff retries, track consecutive failures and disable webhooks that are consistently failing:
+
+```ruby
+# app/models/webhook/delinquency_tracker.rb
+class Webhook::DelinquencyTracker
+  DELINQUENCY_THRESHOLD = 10
+  DELINQUENCY_DURATION = 1.hour
+
+  attr_reader :webhook
+
+  def initialize(webhook)
+    @webhook = webhook
+  end
+
+  def record_delivery_of(delivery)
+    if delivery.delivered?
+      reset
+    else
+      increment
+    end
+  end
+
+  def reset
+    webhook.update!(
+      consecutive_failures: 0,
+      delinquent_until: nil
+    )
+  end
+
+  def delinquent?
+    webhook.delinquent_until.present? && webhook.delinquent_until > Time.current
+  end
+
+  private
+
+  def increment
+    webhook.increment!(:consecutive_failures)
+
+    if webhook.consecutive_failures >= DELINQUENCY_THRESHOLD
+      webhook.update!(delinquent_until: DELINQUENCY_DURATION.from_now)
+    end
+  end
+end
+```
+
+Usage in the delivery job:
+
+```ruby
+class Webhook::DeliveryJob < ApplicationJob
+  def perform(delivery)
+    tracker = Webhook::DelinquencyTracker.new(delivery.webhook)
+
+    if tracker.delinquent?
+      delivery.update!(status: :error, response_body: "Webhook is delinquent - paused delivery")
+      return
+    end
+
+    delivery.perform_request
+    tracker.record_delivery_of(delivery)
+  end
+end
+```
+
+---
+
+## Signature Verification: HMAC-SHA256 (PR #1196)
+
+Allow recipients to verify webhook payloads are authentic:
+
+```ruby
+# app/models/webhook.rb
+class Webhook < ApplicationRecord
+  has_secure_token :signing_secret
+
+  has_many :deliveries, class_name: "Webhook::Delivery", dependent: :destroy
+
+  def sign(payload, timestamp:)
+    data = "#{timestamp}.#{payload}"
+    OpenSSL::HMAC.hexdigest("SHA256", signing_secret, data)
+  end
+end
+```
+
+```ruby
+# In Webhook::Delivery
+class Webhook::Delivery < ApplicationRecord
+  private
+
+  def signed_headers
+    timestamp = Time.current.to_i.to_s
+    signature = webhook.sign(payload, timestamp: timestamp)
+
+    {
+      "Content-Type" => content_type,
+      "X-Webhook-Signature" => signature,
+      "X-Webhook-Timestamp" => timestamp,
+      "User-Agent" => "Compass-Webhooks/1.0"
+    }
+  end
+end
+```
+
+Recipient verification example (for documentation):
+
+```ruby
+# How recipients verify the webhook signature
+def verify_webhook(payload, headers, signing_secret)
+  timestamp = headers["X-Webhook-Timestamp"]
+  expected_signature = headers["X-Webhook-Signature"]
+
+  data = "#{timestamp}.#{payload}"
+  computed = OpenSSL::HMAC.hexdigest("SHA256", signing_secret, data)
+
+  ActiveSupport::SecurityUtils.secure_compare(computed, expected_signature)
+end
+```
+
+---
+
+## Background Job Integration (PR #1196)
+
+### Two-Stage Pattern: WebhookDispatchJob + DeliveryJob
+
+```ruby
+# app/jobs/webhook_dispatch_job.rb
+class WebhookDispatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(event:, deliverable:)
+    webhooks = deliverable.account.webhooks.active
+      .where("events @> ?", [event].to_json)
+
+    webhooks.find_each do |webhook|
+      delivery = webhook.deliveries.create!(
+        event: event,
+        deliverable: deliverable,
+        status: :pending,
+        request_url: webhook.url,
+        request_body: build_payload(event, deliverable, webhook)
+      )
+
+      Webhook::DeliveryJob.perform_later(delivery)
+    end
+  end
+
+  private
+
+  def build_payload(event, deliverable, webhook)
+    Webhook::PayloadFormatter.new(
+      event: event,
+      deliverable: deliverable,
+      webhook: webhook
+    ).to_json
+  end
+end
+```
+
+```ruby
+# app/jobs/webhook/delivery_job.rb
+class Webhook::DeliveryJob < ApplicationJob
+  queue_as :default
+
+  def perform(delivery)
+    tracker = Webhook::DelinquencyTracker.new(delivery.webhook)
+
+    if tracker.delinquent?
+      delivery.update!(status: :error, response_body: "Webhook paused due to failures")
+      return
+    end
+
+    delivery.perform_request
+    tracker.record_delivery_of(delivery)
+  end
+end
+```
+
+### triggered_by Scope
+
+```ruby
+# Query deliveries by event type
+Webhook::Delivery.triggered_by("card.created")
+Webhook::Delivery.triggered_by("comment.created")
+```
+
+---
+
+## Testing Webhooks (PR #1196)
+
+```ruby
+# test/models/webhook/delivery_test.rb
+class Webhook::DeliveryTest < ActiveSupport::TestCase
+  include WebhookTestHelper
+
+  setup do
+    @webhook = webhooks(:active)
+    @delivery = @webhook.deliveries.create!(
+      event: "card.created",
+      deliverable: cards(:one),
+      status: :pending,
+      request_url: @webhook.url,
+      request_body: { card: { id: 1 } }.to_json
+    )
+  end
+
+  test "successful delivery" do
+    stub_request(:post, @webhook.url)
+      .to_return(status: 200, body: "OK")
+
+    @delivery.perform_request
+
+    assert @delivery.delivered?
+    assert_equal 200, @delivery.response_code
+  end
+
+  test "timeout sets timed_out status" do
+    stub_request(:post, @webhook.url).to_timeout
+
+    @delivery.perform_request
+
+    assert @delivery.timed_out?
+  end
+
+  test "response too large is truncated" do
+    large_body = "x" * 100.kilobytes
+    stub_request(:post, @webhook.url)
+      .to_return(status: 200, body: large_body)
+
+    @delivery.perform_request
+
+    assert @delivery.delivered?
+    assert @delivery.response_body.bytesize <= Webhook::Delivery::MAX_RESPONSE_SIZE
+  end
+
+  test "DNS rebinding attack is prevented" do
+    stub_dns_resolution(@webhook.url, "127.0.0.1")
+
+    @delivery.perform_request
+
+    assert @delivery.error?
+    assert_includes @delivery.response_body, "private/internal addresses"
+  end
+
+  test "private IP addresses are rejected" do
+    stub_dns_resolution(@webhook.url, "10.0.0.1")
+
+    @delivery.perform_request
+
+    assert @delivery.error?
+  end
+
+  test "signature is included in headers" do
+    stub_request(:post, @webhook.url)
+      .with { |request|
+        request.headers["X-Webhook-Signature"].present? &&
+        request.headers["X-Webhook-Timestamp"].present?
+      }
+      .to_return(status: 200)
+
+    @delivery.perform_request
+    assert @delivery.delivered?
+  end
+end
+```
+
+### stub_dns_resolution Helper
+
+```ruby
+# test/support/webhook_test_helper.rb
+module WebhookTestHelper
+  def stub_dns_resolution(url, ip_address)
+    hostname = URI.parse(url).host
+    Resolv.stub(:getaddress, ip_address) do
+      yield if block_given?
+    end
+
+    # Alternative: stub at the delivery level
+    Webhook::Delivery.any_instance.stubs(:resolve_ip).returns(ip_address)
+  end
+end
+```
+
+---
+
+## Payload Formatting: Multi-Format Support (PR #1196)
+
+Detect the webhook target service by URL pattern and format the payload accordingly:
+
+```ruby
+# app/models/webhook/payload_formatter.rb
+class Webhook::PayloadFormatter
+  SLACK_URL_PATTERN = /hooks\.slack\.com/
+  CAMPFIRE_URL_PATTERN = /37signals\.com.*\/integrations\/.*\/channels/
+  BASECAMP_URL_PATTERN = /3\.basecamp\.com.*\/integrations/
+
+  attr_reader :event, :deliverable, :webhook
+
+  def initialize(event:, deliverable:, webhook:)
+    @event = event
+    @deliverable = deliverable
+    @webhook = webhook
+  end
+
+  def content_type
+    case webhook.url
+    when SLACK_URL_PATTERN    then "application/json"
+    when CAMPFIRE_URL_PATTERN then "application/json"
+    else "application/json"
+    end
+  end
+
+  def to_json
+    case webhook.url
+    when SLACK_URL_PATTERN
+      slack_payload.to_json
+    when CAMPFIRE_URL_PATTERN
+      campfire_payload.to_json
+    when BASECAMP_URL_PATTERN
+      basecamp_payload.to_json
+    else
+      default_payload.to_json
+    end
+  end
+
+  private
+
+  def default_payload
+    {
+      event: event,
+      created_at: Time.current.iso8601,
+      data: deliverable.as_json
+    }
+  end
+
+  def slack_payload
+    {
+      text: summary_text,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: convert_html_to_mrkdwn(summary_html)
+          }
+        }
+      ]
+    }
+  end
+
+  def campfire_payload
+    { content: summary_text }
+  end
+
+  def basecamp_payload
+    { content: summary_html }
+  end
+
+  def summary_text
+    "#{deliverable.actor.name} #{event.humanize.downcase} in #{deliverable.bucket.name}"
+  end
+
+  def summary_html
+    "<strong>#{deliverable.actor.name}</strong> #{event.humanize.downcase} " \
+      "in <a href=\"#{deliverable_url}\">#{deliverable.bucket.name}</a>"
+  end
+
+  def deliverable_url
+    Rails.application.routes.url_helpers.polymorphic_url(deliverable)
+  end
+
+  def convert_html_to_mrkdwn(html)
+    html
+      .gsub(/<strong>(.*?)<\/strong>/, '*\1*')
+      .gsub(/<em>(.*?)<\/em>/, '_\1_')
+      .gsub(/<a href="(.*?)">(.*?)<\/a>/, '<\1|\2>')
+      .gsub(/<br\s*\/?>/, "\n")
+      .gsub(/<\/?[^>]+>/, '')
+  end
+end
+```
+
+---
+
+## Data Retention: Automatic Cleanup (PR #1292)
+
+```ruby
+# app/models/webhook/delivery.rb
+class Webhook::Delivery < ApplicationRecord
+  STALE_THRESHOLD = 7.days
+
+  scope :stale, -> { where(created_at: ...STALE_THRESHOLD.ago) }
+end
+```
+
+```ruby
+# app/commands/webhook/purge_stale_deliveries_command.rb
+# Using a command (not a class with .call) for consistency
+class Webhook::PurgeStaleDeliveriesCommand
+  def execute
+    Webhook::Delivery.stale.in_batches(of: 1000).delete_all
+  end
+end
+```
+
+```yaml
+# config/recurring.yml
+webhook_cleanup:
+  class: Webhook::PurgeStaleDeliveriesJob
+  schedule: every day at 3am
+  queue: default
+```
+
+```ruby
+# app/jobs/webhook/purge_stale_deliveries_job.rb
+class Webhook::PurgeStaleDeliveriesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Webhook::PurgeStaleDeliveriesCommand.new.execute
+  end
+end
+```
+
+Note: Uses a command separate from the job - the job is the scheduling mechanism, the command is the business logic. This allows the command to be run from console or tests without job infrastructure.
+
+---
+
+## Additional Insights
+
+### Response Size Limiting
+
+```ruby
+MAX_RESPONSE_SIZE = 50.kilobytes
+
+self.response_body = result.body&.truncate(MAX_RESPONSE_SIZE)
+```
+
+Prevents unbounded storage from large webhook responses.
+
+### Timeout Configuration
+
+```ruby
+http.open_timeout = 5   # seconds to establish connection
+http.read_timeout = 10  # seconds to wait for response
+```
+
+Short timeouts prevent webhook deliveries from blocking the job queue.
+
+### URL Validation
+
+```ruby
+class Webhook < ApplicationRecord
+  validates :url, presence: true, format: { with: /\Ahttps:\/\//i, message: "must use HTTPS" }
+  validate :url_is_not_private
+
+  private
+
+  def url_is_not_private
+    ip = Resolv.getaddress(URI.parse(url).host)
+    if SsrfProtection::DISALLOWED_IP_RANGES.any? { |range| range.include?(IPAddr.new(ip)) }
+      errors.add(:url, "cannot point to a private/internal address")
+    end
+  rescue Resolv::ResolvError
+    errors.add(:url, "hostname could not be resolved")
+  end
+end
+```
+
+### User-Friendly Action Labels
+
+```ruby
+class Webhook < ApplicationRecord
+  EVENTS = {
+    "card.created"   => "When a card is created",
+    "card.updated"   => "When a card is updated",
+    "card.closed"    => "When a card is closed",
+    "comment.created" => "When a comment is posted",
+  }.freeze
+
+  def self.event_options
+    EVENTS.map { |value, label| [label, value] }
+  end
+end
+```
+
+### Event Granularity
+
+Events are fine-grained (`card.created` not `card_changed`) so webhook consumers can subscribe to exactly what they need. The `events` column is a JSON array so a single webhook can listen to multiple event types.
+
+---
+
+## Summary: 10 Transferable Patterns
+
+1. **SSRF Protection** - Resolve DNS upfront, validate against private IP ranges, pin IP for the request to prevent DNS rebinding.
+2. **State Machine for Deliveries** - Track pending/delivered/failed/timed_out/error with full request/response logging.
+3. **Delinquency Tracking** - Count consecutive failures; pause delivery after threshold (10 failures = 1 hour pause).
+4. **HMAC-SHA256 Signatures** - Sign `timestamp.payload`, include both signature and timestamp headers.
+5. **Two-Stage Job Pattern** - Dispatch job finds matching webhooks; Delivery job handles each individually.
+6. **Multi-Format Payloads** - URL regex detection for Slack/Campfire/Basecamp; `convert_html_to_mrkdwn` for Slack.
+7. **Response Size Limits** - Truncate stored responses to prevent database bloat.
+8. **Short Timeouts** - 5s open / 10s read to prevent job queue blocking.
+9. **Automatic Data Retention** - Purge deliveries older than 7 days via recurring job.
+10. **URL Validation at Save Time** - HTTPS-only, DNS resolution check, private address rejection on create/update.

--- a/compass/what-they-avoid.md
+++ b/compass/what-they-avoid.md
@@ -1,0 +1,436 @@
+---
+tags: [compass, rails, philosophy, anti-patterns]
+see-also:
+  - "[[philosophy]]"
+  - "[[models]]"
+  - "[[controllers]]"
+---
+
+# What They Avoid
+
+## No Devise (~150 Lines Custom Passwordless)
+
+Instead of the Devise gem (20k+ lines, dozens of modules), authentication is ~150 lines of custom passwordless code:
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  generates_token_for :sign_in, expires_in: 15.minutes
+
+  def send_sign_in_email
+    token = generate_token_for(:sign_in)
+    AuthenticationMailer.sign_in(self, token).deliver_later
+  end
+end
+```
+
+```ruby
+# app/controllers/sessions_controller.rb
+class SessionsController < ApplicationController
+  skip_before_action :authenticate
+
+  def new
+  end
+
+  def create
+    if user = User.find_by(email: params[:email])
+      user.send_sign_in_email
+    end
+
+    redirect_to root_path, notice: "Check your email for a sign-in link"
+  end
+
+  def show
+    user = User.find_by_token_for(:sign_in, params[:token])
+
+    if user
+      start_session_for(user)
+      redirect_to root_path
+    else
+      redirect_to new_session_path, alert: "Invalid or expired link"
+    end
+  end
+
+  def destroy
+    end_session
+    redirect_to root_path
+  end
+
+  private
+
+  def start_session_for(user)
+    session[:user_id] = user.id
+  end
+
+  def end_session
+    session.delete(:user_id)
+  end
+end
+```
+
+Why: Devise is a framework within a framework. Passwordless auth with `generates_token_for` is simple, secure, and fits in your head.
+
+---
+
+## No Pundit/CanCanCan (Simple Predicate Methods on Models)
+
+Authorization is done with plain predicate methods on the model:
+
+```ruby
+# app/models/bucket.rb
+class Bucket < ApplicationRecord
+  def accessible_by?(user)
+    account.users.include?(user)
+  end
+
+  def administerable_by?(user)
+    account.administrators.include?(user)
+  end
+end
+```
+
+```ruby
+# app/models/card.rb
+class Card < ApplicationRecord
+  def visible_to?(user)
+    bucket.accessible_by?(user)
+  end
+
+  def editable_by?(user)
+    creator == user || bucket.administerable_by?(user)
+  end
+
+  def closeable_by?(user)
+    editable_by?(user)
+  end
+end
+```
+
+```ruby
+# app/controllers/cards_controller.rb
+class CardsController < ApplicationController
+  def update
+    @card = current_bucket.cards.find(params[:id])
+
+    unless @card.editable_by?(current_user)
+      return redirect_to @card, alert: "Not authorized"
+    end
+
+    @card.update!(card_params)
+    redirect_to @card
+  end
+end
+```
+
+Why: Authorization policies are domain logic. They belong on the model, not in a separate policy layer.
+
+---
+
+## No Service Objects (CardCloser Anti-Pattern vs Model Method)
+
+### Anti-Pattern: Service Object
+
+```ruby
+# DON'T: app/services/card_closer.rb
+class CardCloser
+  def initialize(card, user)
+    @card = card
+    @user = user
+  end
+
+  def call
+    return unless @card.closeable_by?(@user)
+
+    @card.update!(status: :closed, closed_at: Time.current, closed_by: @user)
+    @card.subscribers.each { |s| NotificationJob.perform_later(s, @card) }
+    @card
+  end
+end
+```
+
+### Correct: Model Method
+
+```ruby
+# DO: app/models/card.rb
+class Card < ApplicationRecord
+  def close(by:)
+    update!(status: :closed, closed_at: Time.current, closed_by: by)
+  end
+end
+```
+
+The controller calls `@card.close(by: current_user)`. Notifications are handled by model callbacks or separate concerns. No need for a `CardCloser` class that just wraps a method call.
+
+Why: Service objects are a sign you're not putting behavior where it belongs. Models should contain domain logic.
+
+---
+
+## No Form Objects (Strong Parameters + Model Validations)
+
+```ruby
+# DON'T: app/forms/card_form.rb
+class CardForm
+  include ActiveModel::Model
+  attr_accessor :title, :body, :assignee_id, :tag_list
+  validates :title, presence: true
+  # ... duplicating model validations
+end
+```
+
+```ruby
+# DO: strong parameters in the controller, validations on the model
+class CardsController < ApplicationController
+  def create
+    @card = current_bucket.cards.create!(card_params)
+    redirect_to @card
+  rescue ActiveRecord::RecordInvalid
+    render :new, status: :unprocessable_entity
+  end
+
+  private
+
+  def card_params
+    params.require(:card).permit(:title, :body, :assignee_id, :tag_list)
+  end
+end
+```
+
+Why: Form objects duplicate validation logic. Strong parameters handle permitted attributes; the model handles validation.
+
+---
+
+## No Decorators/Presenters (View Helpers Instead)
+
+```ruby
+# DON'T: app/decorators/card_decorator.rb
+class CardDecorator < SimpleDelegator
+  def status_badge
+    content_tag(:span, status.titleize, class: "badge badge--#{status}")
+  end
+end
+```
+
+```ruby
+# DO: app/helpers/cards_helper.rb
+module CardsHelper
+  def card_status_badge(card)
+    tag.span(card.status.titleize, class: "badge badge--#{card.status}")
+  end
+
+  def card_due_label(card)
+    if card.overdue?
+      tag.span("Overdue", class: "due-label due-label--overdue")
+    elsif card.due_soon?
+      tag.span("Due soon", class: "due-label due-label--soon")
+    end
+  end
+end
+```
+
+Why: Helpers are built into Rails. Decorators add a layer of indirection for view logic that helpers handle naturally.
+
+---
+
+## No ViewComponent (ERB Partials)
+
+```ruby
+# DON'T: app/components/card_component.rb
+class CardComponent < ViewComponent::Base
+  def initialize(card:)
+    @card = card
+  end
+end
+```
+
+```erb
+<%# DO: app/views/cards/_card.html.erb %>
+<div class="card" id="<%= dom_id(card) %>">
+  <h3><%= link_to card.title, card %></h3>
+  <p><%= card_status_badge(card) %></p>
+  <p><%= card.creator.name %></p>
+</div>
+```
+
+Why: ERB partials are Rails primitives. ViewComponent adds complexity for something that partials and helpers already solve.
+
+---
+
+## No GraphQL (REST + Turbo)
+
+```ruby
+# DON'T: app/graphql/types/card_type.rb
+class Types::CardType < Types::BaseObject
+  field :id, ID, null: false
+  field :title, String, null: false
+  # ...
+end
+```
+
+```ruby
+# DO: standard REST controllers with Turbo responses
+class CardsController < ApplicationController
+  def show
+    @card = current_bucket.cards.find(params[:id])
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
+  end
+end
+```
+
+Why: REST with Turbo handles real-time UI updates without the complexity of a query language. Most apps don't need client-driven data fetching.
+
+---
+
+## No Sidekiq (Solid Queue)
+
+```ruby
+# Uses Solid Queue (built into Rails 8) instead of Sidekiq
+# No Redis dependency for background jobs
+# config/queue.yml is all you need
+
+# config/recurring.yml
+notification_delivery:
+  class: Notification::DeliverAllJob
+  schedule: every 5 minutes
+```
+
+Why: Solid Queue runs on the same database (no Redis). Recurring jobs via `recurring.yml` replace cron and sidekiq-cron. One less infrastructure dependency.
+
+---
+
+## No React/Vue/Frontend Framework (Turbo + Stimulus)
+
+```erb
+<%# Interactive UI with Turbo Frames and Stimulus %>
+<%= turbo_frame_tag dom_id(@card) do %>
+  <div data-controller="toggle">
+    <button data-action="toggle#flip">Edit</button>
+    <div data-toggle-target="content" hidden>
+      <%= render "cards/form", card: @card %>
+    </div>
+  </div>
+<% end %>
+```
+
+Why: Turbo + Stimulus handles 95% of interactivity needs. No build step, no node_modules, no API serialization layer.
+
+---
+
+## No Tailwind CSS (Native CSS with Cascade Layers)
+
+```css
+/* app/assets/stylesheets/application.css */
+@layer base, components, utilities;
+
+@layer components {
+  .card {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+  }
+
+  .badge {
+    display: inline-flex;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-sm);
+    border-radius: var(--radius-full);
+  }
+
+  .badge--open { background: var(--color-green-100); color: var(--color-green-800); }
+  .badge--closed { background: var(--color-gray-100); color: var(--color-gray-800); }
+}
+```
+
+Why: CSS has cascade layers, custom properties, nesting, and container queries natively. No utility class explosion, no build tool dependency.
+
+---
+
+## No RSpec (Minitest)
+
+```ruby
+# DON'T
+RSpec.describe Card do
+  describe "#close" do
+    let(:card) { create(:card) }
+    it { expect(card.close(by: user)).to be_truthy }
+  end
+end
+```
+
+```ruby
+# DO
+class CardTest < ActiveSupport::TestCase
+  test "close sets status and timestamp" do
+    card = cards(:open)
+    card.close(by: users(:david))
+
+    assert card.closed?
+    assert_not_nil card.closed_at
+  end
+end
+```
+
+Why: Minitest is built into Rails. It's plain Ruby - no DSL to learn, no magic matchers, no `let` lazy evaluation surprises.
+
+---
+
+## No FactoryBot (Fixtures)
+
+```yaml
+# test/fixtures/cards.yml
+open:
+  title: Design homepage
+  status: open
+  bucket: first
+  creator: david
+
+closed:
+  title: Old task
+  status: closed
+  closed_at: <%= 1.day.ago %>
+  bucket: first
+  creator: david
+```
+
+```ruby
+# In tests
+test "finds open cards" do
+  assert_includes Card.open, cards(:open)
+  assert_not_includes Card.open, cards(:closed)
+end
+```
+
+Why: Fixtures are loaded once, making tests fast. Factory chains create hidden complexity and N+1 test setups. Fixtures force you to think about your data as a cohesive set.
+
+---
+
+## The Philosophy
+
+> "The best code is no code at all. The second best is code that uses what's already there."
+
+Every dependency is a liability. Every abstraction layer is a place where bugs hide. The Rails framework provides controllers, models, views, helpers, concerns, jobs, and mailers. Use them before reaching for gems. Write the simplest thing that could possibly work, then see if you even need more.
+
+---
+
+## What They DO Use
+
+Gems they actually depend on (beyond Rails defaults):
+
+- **propshaft** - Asset pipeline (Rails 8 default)
+- **solid_queue** - Background jobs (Rails 8 default)
+- **solid_cache** - Cache store (Rails 8 default)
+- **solid_cable** - WebSocket (Rails 8 default)
+- **turbo-rails** - Hotwire Turbo
+- **stimulus-rails** - Hotwire Stimulus
+- **kamal** - Deployment
+- **thruster** - HTTP/2 proxy
+- **image_processing** - Active Storage variants
+- **bcrypt** - Password hashing (if needed)
+- **rack-cors** - CORS for API
+- **webmock** - HTTP stubbing in tests
+- **capybara** - System tests
+- **selenium-webdriver** - Browser testing
+- **rubocop-rails-omakase** - Linting (DHH style)

--- a/compass/workflows.md
+++ b/compass/workflows.md
@@ -1,0 +1,71 @@
+---
+tags: [rails, 37signals, workflows, commands, undo]
+---
+
+# Workflows
+
+> Event-driven state, undoable commands, custom Turbo actions.
+
+See also: [[models]], [[hotwire]], [[filtering]]
+
+---
+
+## Event-Driven State
+Store transitions as events with metadata, not just update fields.
+
+## After-Commit for Defaults
+```ruby
+after_create_commit :create_default_stages
+def create_default_stages
+  Workflow::Stage.insert_all DEFAULT_STAGES.collect { |name| { workflow_id: id, name: name } }
+end
+```
+
+## Undoable Command Pattern
+```ruby
+class Command::Stage < Command
+  store_accessor :data, :stage_id, :original_stage_ids_by_card_id
+  def execute
+    transaction do
+      cards.find_each do |card|
+        original_stage_ids_by_card_id[card.id] = card.stage_id
+        card.change_stage_to stage
+      end
+      update! original_stage_ids_by_card_id: original_stage_ids_by_card_id
+    end
+  end
+  def undo
+    transaction do
+      original_stage_ids_by_card_id.each do |card_id, stage_id|
+        card = affected_cards[card_id.to_i]
+        card&.change_stage_to stages_by_id[stage_id.to_i]
+      end
+    end
+  end
+end
+```
+
+## Custom Turbo Stream Actions
+```javascript
+Turbo.StreamActions.set_css_variable = function() {
+  this.targetElements.forEach(el =>
+    el.style.setProperty(this.getAttribute("name"), this.getAttribute("value"))
+  )
+}
+```
+
+## Computed State from Associations
+```ruby
+def color
+  color_from_stage || Colorable::DEFAULT_COLOR
+end
+```
+Derive state, don't store redundantly.
+
+## Cascading Changes
+```ruby
+after_save :update_bubbles_workflow, if: :saved_change_to_workflow_id?
+def update_bubbles_workflow
+  bubbles.update_all(stage_id: workflow&.stages&.first&.id)
+end
+```


### PR DESCRIPTION
## Summary
Vendor the **37signals Rails Compass** guideline (35 markdown files) into the repo at \`compass/\` so it lives with the application code that follows it.

Source: https://github.com/marckohlbrugge/unofficial-37signals-coding-style-guide

## Why
- Self-contained: cloning the repo brings the style guide along
- Versioned: changes to the guide tracked alongside code they justify
- AI-assistant friendly: assistants reading code can consult \`compass/\` for project conventions

## Test plan
- [ ] Confirm all 35 files present under \`compass/\`
- [ ] Read \`compass/index.md\` to verify entry-point still parses