### PR TITLE
feat(namespaces): nested CRUD with inline modal on project page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,8 +28,8 @@
     --success: oklch(50% 0.12 150);
     --footer-bg: oklch(20% 0 0);
     --footer-fg: oklch(96% 0 0);
-    --radius: 0.5rem;
-    --radius-lg: 0.75rem;
+    --radius: 0.25rem;
+    --radius-lg: 0.25rem;
     --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
     --shadow-card: 0 1px 2px oklch(0% 0 0 / 0.04), 0 4px 12px oklch(0% 0 0 / 0.04);
     --shadow-card-hover: 0 1px 3px oklch(0% 0 0 / 0.06), 0 8px 20px oklch(0% 0 0 / 0.08);
@@ -153,6 +153,7 @@
     justify-content: center;
     gap: 0.375rem;
     width: 100%;
+    max-width: 20rem;
     height: 2.5rem;
     padding: 0 1rem;
     border-radius: var(--radius);
@@ -265,7 +266,7 @@
   .data-table th { font-weight: 600; font-size: 0.875rem; color: var(--muted); }
 
   .stack > * + * { margin-top: 1rem; }
-  .container { max-width: 77.5rem; margin: 0 auto; padding: 2rem 1.5rem; width: 100%; }
+  .container { max-width: 77.5rem; margin: 0 auto; padding: 0 1.5rem; width: 100%; }
 
   .toolbar {
     display: flex;
@@ -284,7 +285,7 @@
     gap: 0.5rem;
     background: var(--bg);
     border: 1px solid var(--border);
-    border-radius: 0.375rem;
+    border-radius: var(--radius);
     padding: 0 0.375rem 0 1rem;
     box-shadow: var(--shadow-sm);
     transition: border-color 120ms ease, box-shadow 120ms ease;
@@ -475,6 +476,16 @@
   .stat-card--namespaces { --stat-glow: oklch(92% 0.09 350 / 0.65); }
   .stat-card--keys       { --stat-glow: oklch(92% 0.09 250 / 0.65); }
   .stat-card--updated    { --stat-glow: oklch(92% 0.09 150 / 0.65); }
+  .stat-card--link {
+    text-decoration: none;
+    color: inherit;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+  }
+  .stat-card--link:hover, .stat-card--link:focus-visible {
+    box-shadow: var(--shadow-card-hover);
+    border-color: var(--accent);
+    transform: translateY(-1px);
+  }
   .stat-card__icon {
     grid-column: 1;
     grid-row: 1;
@@ -565,4 +576,109 @@
 @layer utilities {
   .text-center { text-align: center; }
   .muted { color: var(--muted); }
+  .action-row { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+}
+
+@layer components {
+  .namespaces-section { display: flex; flex-direction: column; gap: 1rem; }
+  .section-header { display: flex; align-items: center; gap: 0.5rem; }
+  .section-header--split { justify-content: space-between; }
+  .section-header__action { max-width: 15rem; }
+  .section-header__title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .modal {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    box-shadow: var(--shadow-card-hover, 0 12px 32px rgba(0,0,0,0.18));
+    max-width: min(32rem, 92vw);
+    width: 100%;
+    inset: 0;
+    margin: auto;
+  }
+  .modal::backdrop { background: rgba(0, 0, 0, 0.45); backdrop-filter: blur(2px); }
+  .modal__inner { display: grid; }
+  .modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .modal__title { margin: 0; font-size: 1.125rem; font-weight: 600; }
+  .modal__body { padding: 1.25rem; gap: 1rem; }
+  .modal__footer {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    padding: 0.75rem 1.25rem;
+    margin: 0.5rem -1.25rem -1.25rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .namespace-new {
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--subtle);
+  }
+  .namespace-new__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .namespace-new__summary::-webkit-details-marker { display: none; }
+  .namespace-new[open] .namespace-new__summary { border-bottom: 1px solid var(--border); color: var(--fg); }
+  .namespace-new__body { padding: 1rem; display: grid; gap: 0.5rem; }
+
+  .namespace-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .namespace-item {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg);
+    box-shadow: var(--shadow-card);
+    overflow: hidden;
+  }
+  .namespace-item__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .namespace-item__summary::-webkit-details-marker { display: none; }
+  .namespace-item__summary:hover { background: var(--subtle); }
+  .namespace-item__icon { color: var(--muted); font-size: 1.125rem; }
+  .namespace-item__name { font-weight: 600; font-family: var(--font-mono, monospace); }
+  .namespace-item__meta { color: var(--muted); font-size: 0.875rem; display: inline-flex; align-items: center; gap: 0.25rem; }
+  .namespace-item__chevron { color: var(--muted); transition: transform 0.15s ease; }
+  .namespace-item[open] > .namespace-item__summary { border-bottom: 1px solid var(--border); }
+  .namespace-item[open] .namespace-item__chevron { transform: rotate(180deg); }
+  .namespace-item__body {
+    padding: 1rem;
+    display: grid;
+    gap: 0.75rem;
+  }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -577,6 +577,7 @@
   .text-center { text-align: center; }
   .muted { color: var(--muted); }
   .action-row { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+  .field--grow { flex: 1; }
 }
 
 @layer components {

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -1,0 +1,49 @@
+class NamespacesController < ApplicationController
+  before_action :set_project
+  before_action :set_namespace,                 only: %i[ update destroy ]
+  before_action :ensure_can_administer_project, only: %i[ create update destroy ]
+
+  def create
+    @namespace = @project.namespaces.build(namespace_params)
+
+    if @namespace.save
+      redirect_to project_path(@project), notice: "Namespace created."
+    else
+      redirect_to project_path(@project, new_namespace: namespace_params[:name]),
+                  alert: @namespace.errors.full_messages.to_sentence,
+                  status: :see_other
+    end
+  end
+
+  def update
+    if @namespace.update(namespace_params)
+      redirect_to project_path(@project), notice: "Namespace updated."
+    else
+      redirect_to project_path(@project),
+                  alert: @namespace.errors.full_messages.to_sentence,
+                  status: :see_other
+    end
+  end
+
+  def destroy
+    @namespace.destroy!
+    redirect_to project_path(@project), notice: "Namespace deleted."
+  end
+
+  private
+    def set_project
+      @project = Project.find_by!(slug: params[:project_id])
+    end
+
+    def set_namespace
+      @namespace = @project.namespaces.find_by!(name: params[:id])
+    end
+
+    def namespace_params
+      params.expect(namespace: %i[ name ])
+    end
+
+    def ensure_can_administer_project
+      head :forbidden unless current_user&.can_administer_project?(@project)
+    end
+end

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -7,32 +7,34 @@ class NamespacesController < ApplicationController
     @namespace = @project.namespaces.build(namespace_params)
 
     if @namespace.save
-      redirect_to project_path(@project), notice: "Namespace created."
+      redirect_to project_path(@project), notice: "Namespace created.", status: :see_other
     else
-      redirect_to project_path(@project, new_namespace: namespace_params[:name]),
-                  alert: @namespace.errors.full_messages.to_sentence,
-                  status: :see_other
+      redirect_with_invalid_namespace
     end
+  rescue ActiveRecord::RecordNotUnique
+    @namespace.errors.add(:name, "has already been taken")
+    redirect_with_invalid_namespace
   end
 
   def update
     if @namespace.update(namespace_params)
-      redirect_to project_path(@project), notice: "Namespace updated."
+      redirect_to project_path(@project), notice: "Namespace updated.", status: :see_other
     else
-      redirect_to project_path(@project),
-                  alert: @namespace.errors.full_messages.to_sentence,
-                  status: :see_other
+      redirect_with_namespace_alert
     end
+  rescue ActiveRecord::RecordNotUnique
+    @namespace.errors.add(:name, "has already been taken")
+    redirect_with_namespace_alert
   end
 
   def destroy
     @namespace.destroy!
-    redirect_to project_path(@project), notice: "Namespace deleted."
+    redirect_to project_path(@project), notice: "Namespace deleted.", status: :see_other
   end
 
   private
     def set_project
-      @project = Project.find_by!(slug: params[:project_id])
+      @project = current_user.accessible_projects.find_by!(slug: params[:project_id])
     end
 
     def set_namespace
@@ -45,5 +47,16 @@ class NamespacesController < ApplicationController
 
     def ensure_can_administer_project
       head :forbidden unless current_user&.can_administer_project?(@project)
+    end
+
+    def redirect_with_invalid_namespace
+      flash[:invalid_namespace_name] = namespace_params[:name]
+      redirect_with_namespace_alert
+    end
+
+    def redirect_with_namespace_alert
+      redirect_to project_path(@project),
+                  alert: @namespace.errors.full_messages.to_sentence,
+                  status: :see_other
     end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,7 +8,8 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    fresh_when etag: [ @project, current_user ]
+    @namespaces = @project.namespaces.alphabetically
+    @new_namespace = @project.namespaces.build(name: params[:new_namespace])
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,13 +3,13 @@ class ProjectsController < ApplicationController
   before_action :ensure_can_administer_project,  only: %i[ new create edit update destroy ]
 
   def index
-    @projects = Project.alphabetically
+    @projects = current_user.accessible_projects.alphabetically
     fresh_when etag: [ @projects, current_user ]
   end
 
   def show
     @namespaces = @project.namespaces.alphabetically
-    @new_namespace = @project.namespaces.build(name: params[:new_namespace])
+    @new_namespace = @project.namespaces.build(name: flash[:invalid_namespace_name])
   end
 
   def new
@@ -44,7 +44,7 @@ class ProjectsController < ApplicationController
 
   private
     def set_project
-      @project = Project.find_by!(slug: params[:id])
+      @project = current_user.accessible_projects.find_by!(slug: params[:id])
     end
 
     def project_params

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -5,11 +5,12 @@ export default class extends Controller {
   static values = { openOnConnect: Boolean }
 
   connect() {
-    if (this.openOnConnectValue) this.open()
+    if (this.openOnConnectValue && this.hasDialogTarget) this.open()
   }
 
   open(event) {
     event?.preventDefault()
+    if (!this.hasDialogTarget || this.dialogTarget.open) return
     this.dialogTarget.showModal()
     const firstInput = this.dialogTarget.querySelector("input, textarea, select")
     firstInput?.focus()
@@ -17,10 +18,10 @@ export default class extends Controller {
 
   close(event) {
     event?.preventDefault()
-    this.dialogTarget.close()
+    if (this.hasDialogTarget && this.dialogTarget.open) this.dialogTarget.close()
   }
 
   closeOnBackdrop(event) {
-    if (event.target === this.dialogTarget) this.dialogTarget.close()
+    if (this.hasDialogTarget && event.target === this.dialogTarget) this.dialogTarget.close()
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog"]
+  static values = { openOnConnect: Boolean }
+
+  connect() {
+    if (this.openOnConnectValue) this.open()
+  }
+
+  open(event) {
+    event?.preventDefault()
+    this.dialogTarget.showModal()
+    const firstInput = this.dialogTarget.querySelector("input, textarea, select")
+    firstInput?.focus()
+  }
+
+  close(event) {
+    event?.preventDefault()
+    this.dialogTarget.close()
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.dialogTarget) this.dialogTarget.close()
+  }
+}

--- a/app/javascript/controllers/slug_input_controller.js
+++ b/app/javascript/controllers/slug_input_controller.js
@@ -3,6 +3,17 @@ import { Controller } from "@hotwired/stimulus"
 const ALLOWED = /[a-z0-9_\-\.]/
 
 export default class extends Controller {
+  prevent(event) {
+    if (event.inputType !== "insertText") return
+    if (!event.data) return
+    for (const ch of event.data.toLowerCase()) {
+      if (!ALLOWED.test(ch)) {
+        event.preventDefault()
+        return
+      }
+    }
+  }
+
   sanitize(event) {
     const input = event.target
     const before = input.value
@@ -23,9 +34,5 @@ export default class extends Controller {
       input.value = cleaned
       input.setSelectionRange(newCaret, newCaret)
     }
-  }
-
-  block(event) {
-    if (event.key === " ") event.preventDefault()
   }
 }

--- a/app/javascript/controllers/slug_input_controller.js
+++ b/app/javascript/controllers/slug_input_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ALLOWED = /[a-z0-9_\-\.]/
+
+export default class extends Controller {
+  sanitize(event) {
+    const input = event.target
+    const before = input.value
+    const caret = input.selectionStart ?? before.length
+
+    let cleaned = ""
+    let newCaret = caret
+    for (let i = 0; i < before.length; i++) {
+      const char = before[i].toLowerCase()
+      if (ALLOWED.test(char)) {
+        cleaned += char
+      } else if (i < caret) {
+        newCaret--
+      }
+    }
+
+    if (cleaned !== before) {
+      input.value = cleaned
+      input.setSelectionRange(newCaret, newCaret)
+    }
+  }
+
+  block(event) {
+    if (event.key === " ") event.preventDefault()
+  }
+}

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -1,0 +1,13 @@
+class Namespace < ApplicationRecord
+  NAME_FORMAT = /\A[a-z0-9][a-z0-9_\-\.]*\z/
+
+  belongs_to :project, counter_cache: true
+
+  validates :name, presence: true,
+                   format: { with: NAME_FORMAT, message: "must be lowercase alnum with -, _, . (no leading separator)" },
+                   uniqueness: { scope: :project_id }
+
+  scope :alphabetically, -> { order(name: :asc) }
+
+  def to_param = name
+end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -1,5 +1,6 @@
 class Namespace < ApplicationRecord
   NAME_FORMAT = /\A[a-z0-9][a-z0-9_\-\.]*\z/
+  private_constant :NAME_FORMAT
 
   belongs_to :project, counter_cache: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 class Project < ApplicationRecord
   before_validation :generate_slug, on: :create
 
+  has_many :namespaces, dependent: :restrict_with_exception
+
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
   def can_administer_project?(_project = nil)
     admin?
   end
+
+  def accessible_projects
+    Project.all
+  end
 end

--- a/app/views/namespaces/_namespace.html.erb
+++ b/app/views/namespaces/_namespace.html.erb
@@ -16,14 +16,14 @@
             local: true,
             data: { controller: "slug-input" } do |form| %>
         <div class="field-row">
-          <div class="field" style="flex: 1;">
+          <div class="field field--grow">
             <%= form.label :name, "Rename" %>
             <%= form.text_field :name, required: true,
                   pattern: "[a-z0-9][a-z0-9_\\-\\.]*",
                   autocomplete: "off",
                   autocapitalize: "none",
                   spellcheck: "false",
-                  data: { action: "input->slug-input#sanitize keydown->slug-input#block" } %>
+                  data: { action: "beforeinput->slug-input#prevent input->slug-input#sanitize" } %>
           </div>
           <%= form.submit "Save", class: "btn" %>
         </div>

--- a/app/views/namespaces/_namespace.html.erb
+++ b/app/views/namespaces/_namespace.html.erb
@@ -1,0 +1,43 @@
+<details class="namespace-item" id="<%= dom_id(namespace) %>">
+  <summary class="namespace-item__summary">
+    <i class="iconoir-folder namespace-item__icon" aria-hidden="true"></i>
+    <span class="namespace-item__name"><%= namespace.name %></span>
+    <span class="namespace-item__meta">
+      <i class="iconoir-translate" aria-hidden="true"></i>
+      <strong><%= namespace.translation_keys_count %></strong> keys
+    </span>
+    <i class="iconoir-nav-arrow-down namespace-item__chevron" aria-hidden="true"></i>
+  </summary>
+
+  <div class="namespace-item__body">
+    <% if current_user.admin? %>
+      <%= form_with model: [ project, namespace ],
+            method: :patch,
+            local: true,
+            data: { controller: "slug-input" } do |form| %>
+        <div class="field-row">
+          <div class="field" style="flex: 1;">
+            <%= form.label :name, "Rename" %>
+            <%= form.text_field :name, required: true,
+                  pattern: "[a-z0-9][a-z0-9_\\-\\.]*",
+                  autocomplete: "off",
+                  autocapitalize: "none",
+                  spellcheck: "false",
+                  data: { action: "input->slug-input#sanitize keydown->slug-input#block" } %>
+          </div>
+          <%= form.submit "Save", class: "btn" %>
+        </div>
+      <% end %>
+
+      <%= button_to project_namespace_path(project, namespace),
+            method: :delete,
+            class: "btn btn-secondary btn--danger",
+            data: { turbo_confirm: "Delete namespace \"#{namespace.name}\"? This cannot be undone." } do %>
+        <i class="iconoir-trash" aria-hidden="true"></i>
+        Delete namespace
+      <% end %>
+    <% else %>
+      <p class="muted">Read-only view.</p>
+    <% end %>
+  </div>
+</details>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -82,5 +82,76 @@
     </article>
   </div>
 
-  <p class="muted">Locales, namespaces and keys will be managed here soon.</p>
+  <section class="namespaces-section"
+           data-controller="modal"
+           data-modal-open-on-connect-value="<%= @new_namespace.name.present? %>">
+    <header class="section-header section-header--split">
+      <h2 class="section-header__title">
+        <i class="iconoir-folder" aria-hidden="true"></i>
+        Namespaces
+      </h2>
+      <% if current_user.admin? %>
+        <button type="button" class="btn section-header__action" data-action="click->modal#open">
+          <i class="iconoir-plus" aria-hidden="true"></i>
+          New namespace
+        </button>
+      <% end %>
+    </header>
+
+    <% if current_user.admin? %>
+      <dialog class="modal" data-modal-target="dialog" data-action="click->modal#closeOnBackdrop">
+        <div class="modal__inner">
+          <header class="modal__header">
+            <h3 class="modal__title">New namespace</h3>
+            <button type="button" class="icon-btn" data-action="click->modal#close" aria-label="Close">
+              <i class="iconoir-xmark" aria-hidden="true"></i>
+            </button>
+          </header>
+
+          <%= form_with model: [ @project, @new_namespace ], local: true, data: { controller: "slug-input" }, html: { class: "modal__body stack" } do |form| %>
+            <div class="field">
+              <%= form.label :name, "Name" %>
+              <%= form.text_field :name, required: true,
+                    placeholder: "common, auth, marketing.cta",
+                    pattern: "[a-z0-9][a-z0-9_\\-\\.]*",
+                    autocomplete: "off",
+                    autocapitalize: "none",
+                    spellcheck: "false",
+                    data: { action: "input->slug-input#sanitize keydown->slug-input#block" } %>
+              <small class="muted">Lowercase letters, digits, <code>-</code>, <code>_</code>, <code>.</code> (no leading separator).</small>
+            </div>
+
+            <footer class="modal__footer">
+              <button type="button" class="btn btn-secondary" data-action="click->modal#close">Cancel</button>
+              <%= form.submit "Create", class: "btn" %>
+            </footer>
+          <% end %>
+        </div>
+      </dialog>
+    <% end %>
+
+    <% if @namespaces.any? %>
+      <ul class="namespace-list">
+        <% @namespaces.each do |namespace| %>
+          <li>
+            <%= render "namespaces/namespace", namespace: namespace, project: @project %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="empty-state">
+        <%= image_tag "empty-projects.png", class: "empty-state__image", alt: "" %>
+        <h2>No namespaces yet</h2>
+        <p>Namespaces group translation keys (e.g. <code>common</code>, <code>auth</code>, <code>marketing.cta</code>).</p>
+        <% if current_user.admin? %>
+          <div class="empty-state__actions">
+            <button type="button" class="btn" data-action="click->modal#open">
+              <i class="iconoir-plus" aria-hidden="true"></i>
+              Create first namespace
+            </button>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
 </section>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -99,10 +99,13 @@
     </header>
 
     <% if current_user.admin? %>
-      <dialog class="modal" data-modal-target="dialog" data-action="click->modal#closeOnBackdrop">
+      <dialog class="modal"
+              data-modal-target="dialog"
+              data-action="click->modal#closeOnBackdrop"
+              aria-labelledby="new-namespace-title">
         <div class="modal__inner">
           <header class="modal__header">
-            <h3 class="modal__title">New namespace</h3>
+            <h3 id="new-namespace-title" class="modal__title">New namespace</h3>
             <button type="button" class="icon-btn" data-action="click->modal#close" aria-label="Close">
               <i class="iconoir-xmark" aria-hidden="true"></i>
             </button>
@@ -117,7 +120,7 @@
                     autocomplete: "off",
                     autocapitalize: "none",
                     spellcheck: "false",
-                    data: { action: "input->slug-input#sanitize keydown->slug-input#block" } %>
+                    data: { action: "beforeinput->slug-input#prevent input->slug-input#sanitize" } %>
               <small class="muted">Lowercase letters, digits, <code>-</code>, <code>_</code>, <code>.</code> (no leading separator).</small>
             </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
   get  "invitations/:token", to: "invitations#show",   as: :accept_invitation
   post "invitations/:token", to: "invitations#accept", as: :claim_invitation
 
-  resources :projects, only: %i[ index new create show edit update destroy ]
+  resources :projects, only: %i[ index new create show edit update destroy ] do
+    resources :namespaces, only: %i[ create update destroy ], constraints: { id: %r{[^/]+} }
+  end
 
   root "projects#index"
 end

--- a/db/migrate/20260426060000_create_namespaces.rb
+++ b/db/migrate/20260426060000_create_namespaces.rb
@@ -1,7 +1,7 @@
 class CreateNamespaces < ActiveRecord::Migration[8.1]
   def change
     create_table :namespaces, id: :uuid, default: -> { "uuidv7()" } do |t|
-      t.references :project, null: false, foreign_key: true, type: :uuid
+      t.references :project, null: false, foreign_key: true, type: :uuid, index: false
       t.string :name, null: false
       t.integer :translation_keys_count, null: false, default: 0
 

--- a/db/migrate/20260426060000_create_namespaces.rb
+++ b/db/migrate/20260426060000_create_namespaces.rb
@@ -1,0 +1,13 @@
+class CreateNamespaces < ActiveRecord::Migration[8.1]
+  def change
+    create_table :namespaces, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :project, null: false, foreign_key: true, type: :uuid
+      t.string :name, null: false
+      t.integer :translation_keys_count, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :namespaces, [ :project_id, :name ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_060000) do
     t.integer "translation_keys_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["project_id", "name"], name: "index_namespaces_on_project_id_and_name", unique: true
-    t.index ["project_id"], name: "index_namespaces_on_project_id"
   end
 
   create_table "projects", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_053621) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_053621) do
     t.index ["email"], name: "index_invitations_on_email", unique: true, where: "(accepted_at IS NULL)"
     t.index ["inviter_id"], name: "index_invitations_on_inviter_id"
     t.index ["token"], name: "index_invitations_on_token", unique: true
+  end
+
+  create_table "namespaces", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.uuid "project_id", null: false
+    t.integer "translation_keys_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "name"], name: "index_namespaces_on_project_id_and_name", unique: true
+    t.index ["project_id"], name: "index_namespaces_on_project_id"
   end
 
   create_table "projects", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -69,6 +79,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_053621) do
   end
 
   add_foreign_key "invitations", "users", column: "inviter_id"
+  add_foreign_key "namespaces", "projects"
   add_foreign_key "sessions", "users"
   add_foreign_key "sign_in_tokens", "users"
 end

--- a/test/controllers/namespaces_controller_test.rb
+++ b/test/controllers/namespaces_controller_test.rb
@@ -1,0 +1,123 @@
+require "test_helper"
+
+class NamespacesControllerTest < ActionDispatch::IntegrationTest
+  test "non-admin cannot create/update/destroy" do
+    sign_in_as(users(:translator))
+    project = projects(:main_app)
+    namespace = namespaces(:main_app_common)
+
+    assert_no_difference "Namespace.count" do
+      post project_namespaces_path(project), params: { namespace: { name: "sneaky" } }
+    end
+    assert_response :forbidden
+
+    patch project_namespace_path(project, namespace), params: { namespace: { name: "hijacked" } }
+    assert_response :forbidden
+    assert_equal "common", namespace.reload.name
+
+    assert_no_difference "Namespace.count" do
+      delete project_namespace_path(project, namespace)
+    end
+    assert_response :forbidden
+  end
+
+  test "admin creates namespace" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+
+    assert_difference "project.namespaces.count", 1 do
+      post project_namespaces_path(project), params: { namespace: { name: "checkout" } }
+    end
+
+    assert_redirected_to project_path(project)
+    assert_match(/Namespace created/, flash[:notice])
+    assert project.namespaces.exists?(name: "checkout")
+  end
+
+  test "admin sees alert and pre-filled form when creating with blank name" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+
+    assert_no_difference "Namespace.count" do
+      post project_namespaces_path(project), params: { namespace: { name: "" } }
+    end
+    assert_redirected_to project_path(project, new_namespace: "")
+    assert_match(/blank/i, flash[:alert])
+  end
+
+  test "admin sees alert when creating with invalid format" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+
+    assert_no_difference "Namespace.count" do
+      post project_namespaces_path(project), params: { namespace: { name: "Has Space" } }
+    end
+    assert_redirected_to project_path(project, new_namespace: "Has Space")
+    assert flash[:alert].present?
+  end
+
+  test "admin updates namespace" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+    namespace = namespaces(:main_app_marketing)
+
+    patch project_namespace_path(project, namespace), params: { namespace: { name: "marketing-v2" } }
+
+    assert_redirected_to project_path(project)
+    assert_equal "marketing-v2", namespace.reload.name
+  end
+
+  test "admin destroys namespace" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+    namespace = project.namespaces.create!(name: "disposable")
+
+    assert_difference "project.namespaces.count", -1 do
+      delete project_namespace_path(project, namespace)
+    end
+    assert_redirected_to project_path(project)
+  end
+
+  test "404 on unknown project slug" do
+    sign_in_as(users(:admin))
+    post project_namespaces_path("does-not-exist"), params: { namespace: { name: "x" } }
+    assert_response :not_found
+  end
+
+  test "namespace name with dots routes correctly" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+    namespace = project.namespaces.create!(name: "marketing.cta")
+
+    patch project_namespace_path(project, namespace), params: { namespace: { name: "marketing.cta.v2" } }
+    assert_redirected_to project_path(project)
+    assert_equal "marketing.cta.v2", namespace.reload.name
+  end
+
+  test "project show lists namespaces" do
+    sign_in_as(users(:translator))
+    get project_path(projects(:main_app))
+    assert_response :success
+    assert_select ".namespace-item", count: projects(:main_app).namespaces.count
+  end
+
+  test "project show hides admin actions for non-admin" do
+    sign_in_as(users(:translator))
+    get project_path(projects(:main_app))
+    assert_select "button", text: /New namespace/, count: 0
+    assert_select "dialog.modal", count: 0
+  end
+
+  test "project show shows new-namespace button for admin" do
+    sign_in_as(users(:admin))
+    get project_path(projects(:main_app))
+    assert_select "button", text: /New namespace/
+    assert_select "dialog.modal"
+  end
+
+  private
+    def sign_in_as(user)
+      token = user.sign_in_tokens.create!
+      get sign_in_with_token_path(token: token.token)
+    end
+end

--- a/test/controllers/namespaces_controller_test.rb
+++ b/test/controllers/namespaces_controller_test.rb
@@ -41,7 +41,7 @@ class NamespacesControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "Namespace.count" do
       post project_namespaces_path(project), params: { namespace: { name: "" } }
     end
-    assert_redirected_to project_path(project, new_namespace: "")
+    assert_redirected_to project_path(project)
     assert_match(/blank/i, flash[:alert])
   end
 
@@ -52,8 +52,41 @@ class NamespacesControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "Namespace.count" do
       post project_namespaces_path(project), params: { namespace: { name: "Has Space" } }
     end
-    assert_redirected_to project_path(project, new_namespace: "Has Space")
+    assert_redirected_to project_path(project)
     assert flash[:alert].present?
+    assert_equal "Has Space", flash[:invalid_namespace_name]
+  end
+
+  test "duplicate name caught by validation returns alert" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+    project.namespaces.create!(name: "racing")
+
+    assert_no_difference "Namespace.count" do
+      post project_namespaces_path(project), params: { namespace: { name: "racing" } }
+    end
+    assert flash[:alert].present?
+  end
+
+  test "rescues RecordNotUnique when validation is bypassed (true race)" do
+    sign_in_as(users(:admin))
+    project = projects(:main_app)
+    project.namespaces.create!(name: "raced")
+
+    uniqueness_validator = Namespace.validators_on(:name).find { |v| v.is_a?(ActiveRecord::Validations::UniquenessValidator) }
+    Namespace._validators[:name].delete(uniqueness_validator)
+    Namespace.skip_callback(:validate, :before, uniqueness_validator)
+
+    begin
+      assert_no_difference "Namespace.count" do
+        post project_namespaces_path(project), params: { namespace: { name: "raced" } }
+      end
+      assert_redirected_to project_path(project)
+      assert_match(/already been taken/i, flash[:alert])
+    ensure
+      Namespace._validators[:name] << uniqueness_validator
+      Namespace.set_callback(:validate, :before, uniqueness_validator)
+    end
   end
 
   test "admin updates namespace" do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -96,9 +96,10 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "admin destroys project" do
     sign_in_as(users(:admin))
+    project = Project.create!(name: "Disposable")
 
     assert_difference "Project.count", -1 do
-      delete project_path(projects(:main_app))
+      delete project_path(project)
     end
     assert_redirected_to projects_path
   end

--- a/test/fixtures/namespaces.yml
+++ b/test/fixtures/namespaces.yml
@@ -1,0 +1,11 @@
+main_app_common:
+  project: main_app
+  name: common
+
+main_app_marketing:
+  project: main_app
+  name: marketing
+
+marketing_site_common:
+  project: marketing_site
+  name: common

--- a/test/models/namespace_test.rb
+++ b/test/models/namespace_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class NamespaceTest < ActiveSupport::TestCase
+  test "valid with project and name" do
+    namespace = Namespace.new(project: projects(:main_app), name: "auth")
+    assert namespace.valid?
+  end
+
+  test "requires project" do
+    namespace = Namespace.new(name: "auth")
+    assert_not namespace.valid?
+    assert_includes namespace.errors[:project], "must exist"
+  end
+
+  test "requires name" do
+    namespace = Namespace.new(project: projects(:main_app))
+    assert_not namespace.valid?
+    assert_includes namespace.errors[:name], "can't be blank"
+  end
+
+  test "rejects invalid name formats" do
+    %w[Common .leading-dot has\ space UPPER weird@char -leading-dash].each do |bad|
+      namespace = Namespace.new(project: projects(:main_app), name: bad)
+      assert_not namespace.valid?, "expected #{bad.inspect} to be invalid"
+      assert namespace.errors[:name].any?
+    end
+  end
+
+  test "accepts valid name formats" do
+    project = Project.create!(name: "Format Test")
+    %w[auth auth-flow marketing.cta v2_buttons a 1 a.b.c].each do |good|
+      namespace = Namespace.new(project: project, name: good)
+      assert namespace.valid?, "expected #{good.inspect} to be valid (errors: #{namespace.errors.full_messages})"
+    end
+  end
+
+  test "name unique per project" do
+    duplicate = Namespace.new(project: projects(:main_app), name: namespaces(:main_app_common).name)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:name], "has already been taken"
+  end
+
+  test "same name allowed across different projects" do
+    namespace = Namespace.new(project: projects(:marketing_site), name: namespaces(:main_app_marketing).name)
+    assert namespace.valid?
+  end
+
+  test "destroying project with namespaces is restricted" do
+    project = Project.create!(name: "Restricted")
+    project.namespaces.create!(name: "auth")
+    assert_raises(ActiveRecord::DeleteRestrictionError) { project.destroy! }
+  end
+
+  test "counter cache increments project.namespaces_count on create" do
+    project = Project.create!(name: "Counter Test")
+    assert_difference -> { project.reload.namespaces_count }, 1 do
+      project.namespaces.create!(name: "auth")
+    end
+  end
+
+  test "counter cache decrements project.namespaces_count on destroy" do
+    project = Project.create!(name: "Counter Decrement")
+    namespace = project.namespaces.create!(name: "auth")
+    assert_difference -> { project.reload.namespaces_count }, -1 do
+      namespace.destroy!
+    end
+  end
+
+  test "alphabetically scope orders by name asc" do
+    project = projects(:main_app)
+    assert_equal project.namespaces.alphabetically.pluck(:name), project.namespaces.pluck(:name).sort
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `namespaces` table (UUIDv7, unique on `(project_id, name)`), `Namespace` model with counter cache + format/uniqueness validations, and full Minitest coverage. Closes #7 and #14.
- Wires nested `projects/:slug/namespaces` resources, lists namespaces inline on the project show as `<details>` collapsibles with rename + delete, and ships a native `<dialog>` modal for creation triggered by a right-aligned header button.
- New Stimulus controllers: `modal` (showModal + backdrop dismiss) and `slug-input` (masks lowercase alnum + `-_.`, paste-safe with caret preservation).
- Tightened global design tokens: `--radius` and `--radius-lg` both 4px, `.btn` capped at 20rem (15rem on section actions), container vertical padding removed.

## Test plan
- [x] `bin/rails test` — 76 runs, 266 assertions, 0 failures
- [x] `bin/rubocop` clean on touched files
- [ ] Sign in as admin, create namespace via modal, rename inline, delete; verify `namespaces_count` updates on Project show
- [ ] Verify mask blocks uppercase/spaces/punctuation in real browser
- [ ] Verify `<dialog>` Esc and backdrop dismiss