### PR TITLE
fix(deps): bump net-imap to 0.6.4.1 for CVE-2026-47240/47241

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## Why
The `scan_ruby` CI job fails on `main` (`bin/bundler-audit` step) due to known vulnerabilities in **net-imap 0.6.4** — a transitive dependency with no dependabot PR.

- **CVE-2026-47240** (Medium): Net::IMAP command injection via non-synchronizing literal in `raw` argument
- **CVE-2026-47241** (Low): Net::IMAP DoS via incomplete `raw` argument validation

Fixed in `>= 0.6.4.1`.

## What
`bundle update net-imap --conservative` → `0.6.4` → `0.6.4.1`. One line in `Gemfile.lock`.

## Verification
- `bundle exec bundler-audit check --update` → **No vulnerabilities found**
- `bin/brakeman --no-pager` → **No warnings found** (exit 0)

The other prior `scan_ruby` failures (brakeman `--ensure-latest`, puma & nokogiri CVEs) were already resolved by the recently merged dependabot bumps (#70, #67, transitive #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)