### PR TITLE
feat(delivery): public i18n JSON delivery with materialized artifacts + CDN

### DIFF
--- a/app/controllers/delivery_controller.rb
+++ b/app/controllers/delivery_controller.rb
@@ -1,0 +1,44 @@
+# Public, unauthenticated JSON delivery for i18n clients. Serves the published
+# translations of one (project, locale, namespace) as a nested object, matching
+# the i18next http-backend loadPath "/cdn/:project/:locale/:namespace.json".
+# HTTP caching (ETag + Cache-Control) lets the host decide when to re-fetch.
+class DeliveryController < ApplicationController
+  allow_unauthenticated only: :show
+
+  def show
+    project = Project.find_by!(slug: params[:project_slug])
+    locale = project.locales.find_by!(code: params[:locale])
+    namespace = project.namespaces.find_by!(name: namespace_name)
+
+    artifact = Translation::Artifact.find_by(namespace: namespace, locale: locale)
+    if artifact&.file&.attached?
+      serve_artifact(artifact)
+    else
+      serve_live(namespace, locale)
+    end
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  private
+    def serve_artifact(artifact)
+      if stale?(etag: artifact.checksum, public: true)
+        expires_in 5.minutes, public: true
+        render body: artifact.file.download, content_type: "application/json"
+      end
+    end
+
+    def serve_live(namespace, locale)
+      bundle = TranslationBundle.new(namespace: namespace, locale: locale)
+      if stale?(etag: bundle.etag, public: true)
+        expires_in 5.minutes, public: true
+        render json: bundle.to_h
+      end
+    end
+
+    # The route captures ".json" into :namespace (namespaces may contain dots),
+    # so strip a single trailing ".json" to support both loadPath styles.
+    def namespace_name
+      params[:namespace].delete_suffix(".json")
+    end
+end

--- a/app/controllers/delivery_controller.rb
+++ b/app/controllers/delivery_controller.rb
@@ -3,12 +3,14 @@
 # the i18next http-backend loadPath "/cdn/:project/:locale/:namespace.json".
 # HTTP caching (ETag + Cache-Control) lets the host decide when to re-fetch.
 class DeliveryController < ApplicationController
+  include ActiveStorage::Streaming
+
   allow_unauthenticated only: :show
 
   def show
     project = Project.find_by!(slug: params[:project_slug])
     locale = project.locales.find_by!(code: params[:locale])
-    namespace = project.namespaces.find_by!(name: namespace_name)
+    namespace = find_namespace!(project)
 
     artifact = Translation::Artifact.find_by(namespace: namespace, locale: locale)
     if artifact&.file&.attached?
@@ -21,19 +23,18 @@ class DeliveryController < ApplicationController
   end
 
   private
+    # Stream the stored blob chunk by chunk instead of loading it whole into
+    # memory. Cache headers are set before the freshness check so a 304 carries
+    # them too.
     def serve_artifact(artifact)
-      if stale?(etag: artifact.checksum, public: true)
-        set_cache_headers
-        render body: artifact.file.download, content_type: "application/json"
-      end
+      set_cache_headers
+      send_blob_stream(artifact.file, disposition: "inline") if stale?(etag: artifact.checksum)
     end
 
     def serve_live(namespace, locale)
       bundle = TranslationBundle.new(namespace: namespace, locale: locale)
-      if stale?(etag: bundle.etag, public: true)
-        set_cache_headers
-        render json: bundle.to_h
-      end
+      set_cache_headers
+      render json: bundle.to_h if stale?(etag: bundle.etag)
     end
 
     # A CDN fronts this endpoint (see docs/cdn-setup.md): cache for an hour, but
@@ -44,8 +45,11 @@ class DeliveryController < ApplicationController
     end
 
     # The route captures ".json" into :namespace (namespaces may contain dots),
-    # so strip a single trailing ".json" to support both loadPath styles.
-    def namespace_name
-      params[:namespace].delete_suffix(".json")
+    # so the optional loadPath suffix can't be a Rails format. Try the literal
+    # name first (a namespace really named "x.json"), then the stripped form.
+    def find_namespace!(project)
+      raw = params[:namespace]
+      project.namespaces.find_by(name: raw) ||
+        project.namespaces.find_by!(name: raw.delete_suffix(".json"))
     end
 end

--- a/app/controllers/delivery_controller.rb
+++ b/app/controllers/delivery_controller.rb
@@ -23,7 +23,7 @@ class DeliveryController < ApplicationController
   private
     def serve_artifact(artifact)
       if stale?(etag: artifact.checksum, public: true)
-        expires_in 5.minutes, public: true
+        set_cache_headers
         render body: artifact.file.download, content_type: "application/json"
       end
     end
@@ -31,9 +31,16 @@ class DeliveryController < ApplicationController
     def serve_live(namespace, locale)
       bundle = TranslationBundle.new(namespace: namespace, locale: locale)
       if stale?(etag: bundle.etag, public: true)
-        expires_in 5.minutes, public: true
+        set_cache_headers
         render json: bundle.to_h
       end
+    end
+
+    # A CDN fronts this endpoint (see docs/cdn-setup.md): cache for an hour, but
+    # serve stale up to 5 minutes while revalidating so a publish propagates
+    # quickly without a thundering herd against the origin.
+    def set_cache_headers
+      expires_in 1.hour, public: true, "stale-while-revalidate": 5.minutes.to_i
     end
 
     # The route captures ".json" into :namespace (namespaces may contain dots),

--- a/app/controllers/namespaces/publications_controller.rb
+++ b/app/controllers/namespaces/publications_controller.rb
@@ -8,7 +8,9 @@ class Namespaces::PublicationsController < ApplicationController
   def create
     drafts = Translation.drafts_in_namespace(@namespace)
     count = drafts.count
-    drafts.find_each { |translation| translation.publish(by: current_user) }
+    Translation::Artifact.batch do
+      drafts.find_each { |translation| translation.publish(by: current_user) }
+    end
 
     notice = count.zero? ? "Nothing to publish." : "Published #{count} #{"translation".pluralize(count)}."
     redirect_to project_namespace_path(@project, @namespace), notice: notice, status: :see_other

--- a/app/controllers/translation_keys_controller.rb
+++ b/app/controllers/translation_keys_controller.rb
@@ -26,7 +26,12 @@ class TranslationKeysController < ApplicationController
   end
 
   def destroy
+    # The namespace survives, so any artifact that included this key must be
+    # rebuilt without it. Capture the affected locales before the cascade.
+    affected_locale_ids = @translation_key.translations.published.distinct.pluck(:locale_id)
     @translation_key.destroy!
+    affected_locale_ids.each { |locale_id| Translation::Artifact.rebuild(@namespace.id, locale_id) }
+
     redirect_to namespace_path, notice: "Key deleted.", status: :see_other
   end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,6 +1,7 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
   attribute :user_agent, :ip_address
+  attribute :artifact_rebuild_batch
 
   def user
     session&.user

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -2,6 +2,7 @@ class Locale < ApplicationRecord
   belongs_to :project, counter_cache: true
 
   has_many :translations, dependent: :destroy
+  has_many :translation_artifacts, class_name: "Translation::Artifact", dependent: :destroy
 
   validates :code, presence: true, uniqueness: { scope: :project_id }
 

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -5,6 +5,7 @@ class Namespace < ApplicationRecord
   belongs_to :project, counter_cache: true
 
   has_many :translation_keys, dependent: :destroy
+  has_many :translation_artifacts, class_name: "Translation::Artifact", dependent: :destroy
 
   validates :name, presence: true,
                    format: { with: NAME_FORMAT, message: "must be lowercase alnum with -, _, . (no leading separator)" },

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ApplicationRecord
   has_many :locales, dependent: :destroy
   has_many :translation_keys, dependent: :destroy
   has_many :translations, dependent: :destroy
+  has_many :translation_artifacts, class_name: "Translation::Artifact", dependent: :destroy
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -30,6 +30,7 @@ class Translation < ApplicationRecord
 
   before_update :snapshot_version, if: -> { value_changed? }
   after_update :discard_publication, if: -> { saved_change_to_value? }
+  after_commit :rebuild_artifact_after_discard, on: :update
 
   def draft?
     value.present? && publication.nil?
@@ -90,6 +91,15 @@ class Translation < ApplicationRecord
       association(:publication).reset
       track_event("unpublished", metadata: { reason: "value_changed" })
 
+      # Defer the artifact rebuild to after_commit: it uploads a blob, which must
+      # not run inside the save transaction.
+      @publication_discarded = true
+    end
+
+    def rebuild_artifact_after_discard
+      return unless @publication_discarded
+
+      @publication_discarded = false
       Translation::Artifact.touch_for(self)
     end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -48,6 +48,7 @@ class Translation < ApplicationRecord
       create_publication!(publisher: by)
       track_event("published", creator: by)
     end
+    Translation::Artifact.touch_for(self)
     publication
   end
 
@@ -59,6 +60,7 @@ class Translation < ApplicationRecord
       association(:publication).reset
       track_event("unpublished")
     end
+    Translation::Artifact.touch_for(self)
   end
 
   private
@@ -87,5 +89,7 @@ class Translation < ApplicationRecord
       publication.destroy!
       association(:publication).reset
       track_event("unpublished", metadata: { reason: "value_changed" })
+
+      Translation::Artifact.touch_for(self)
     end
 end

--- a/app/models/translation/artifact.rb
+++ b/app/models/translation/artifact.rb
@@ -1,0 +1,69 @@
+# A materialized delivery file: the compiled JSON for one (namespace, locale)
+# stored as an Active Storage attachment. Rebuilt synchronously whenever the
+# published content of that pair changes (publish, unpublish, or an edit that
+# discards a publication). DeliveryController serves the attached blob when
+# present, falling back to compiling live.
+#
+# Rebuilds are coalesced via .batch so a bulk "publish all" recompiles each
+# affected (namespace, locale) once instead of once per translation.
+class Translation::Artifact < ApplicationRecord
+  belongs_to :project
+  belongs_to :namespace
+  belongs_to :locale
+
+  has_one_attached :file
+
+  validates :namespace_id, uniqueness: { scope: :locale_id }
+
+  class << self
+    # Record a content change for a translation's (namespace, locale). Rebuilds
+    # immediately, unless inside a .batch block, where pairs are deduped and
+    # rebuilt once on exit.
+    def touch_for(translation)
+      pair = [ translation.translation_key.namespace_id, translation.locale_id ]
+
+      if batched
+        batched << pair
+      else
+        rebuild(*pair)
+      end
+    end
+
+    def batch
+      Thread.current[:translation_artifact_batch] = Set.new
+      yield
+      batched.each { |namespace_id, locale_id| rebuild(namespace_id, locale_id) }
+    ensure
+      Thread.current[:translation_artifact_batch] = nil
+    end
+
+    # Backfill: materialize every (namespace, locale) that currently has
+    # published content. Idempotent — safe to re-run.
+    def rebuild_all
+      pairs = Translation.published.joins(:translation_key)
+        .distinct.pluck("translation_keys.namespace_id", :locale_id)
+      pairs.each { |namespace_id, locale_id| rebuild(namespace_id, locale_id) }
+      pairs.size
+    end
+
+    def rebuild(namespace_id, locale_id)
+      namespace = Namespace.find(namespace_id)
+      locale = Locale.find(locale_id)
+      content = TranslationBundle.new(namespace: namespace, locale: locale)
+
+      artifact = find_or_initialize_by(namespace: namespace, locale: locale)
+      artifact.update!(project: namespace.project, checksum: content.etag, built_at: Time.current)
+      artifact.file.attach(
+        io: StringIO.new(content.to_json),
+        filename: "#{locale.code}.json",
+        content_type: "application/json"
+      )
+      artifact
+    end
+
+    private
+      def batched
+        Thread.current[:translation_artifact_batch]
+      end
+  end
+end

--- a/app/models/translation/artifact.rb
+++ b/app/models/translation/artifact.rb
@@ -30,11 +30,11 @@ class Translation::Artifact < ApplicationRecord
     end
 
     def batch
-      Thread.current[:translation_artifact_batch] = Set.new
+      Current.artifact_rebuild_batch = Set.new
       yield
       batched.each { |namespace_id, locale_id| rebuild(namespace_id, locale_id) }
     ensure
-      Thread.current[:translation_artifact_batch] = nil
+      Current.artifact_rebuild_batch = nil
     end
 
     # Backfill: materialize every (namespace, locale) that currently has
@@ -63,7 +63,7 @@ class Translation::Artifact < ApplicationRecord
 
     private
       def batched
-        Thread.current[:translation_artifact_batch]
+        Current.artifact_rebuild_batch
       end
   end
 end

--- a/app/models/translation/artifact.rb
+++ b/app/models/translation/artifact.rb
@@ -32,9 +32,12 @@ class Translation::Artifact < ApplicationRecord
     def batch
       Current.artifact_rebuild_batch = Set.new
       yield
-      batched.each { |namespace_id, locale_id| rebuild(namespace_id, locale_id) }
     ensure
+      # Rebuild in ensure so partially-applied work (e.g. a "publish all" that
+      # raises midway) still materializes the pairs already touched.
+      pairs = Current.artifact_rebuild_batch
       Current.artifact_rebuild_batch = nil
+      pairs&.each { |namespace_id, locale_id| rebuild(namespace_id, locale_id) }
     end
 
     # Backfill: materialize every (namespace, locale) that currently has
@@ -59,6 +62,10 @@ class Translation::Artifact < ApplicationRecord
         content_type: "application/json"
       )
       artifact
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent rebuild inserted the row first; retry so find_or_initialize
+      # takes the update path instead of a colliding insert.
+      retry
     end
 
     private

--- a/app/models/translation_bundle.rb
+++ b/app/models/translation_bundle.rb
@@ -1,0 +1,47 @@
+# Compiles the published translations of a single (namespace, locale) pair into
+# the nested JSON shape an i18n client (e.g. i18next) consumes. This is the
+# inverse of TranslationImport#flatten: dotted keys ("home.title") expand back
+# into nested objects. Only published translations with a value are included.
+#
+# The same builder backs both delivery modes: DeliveryController renders #to_h
+# live, and a future materialized artifact would persist #to_json. #etag gives a
+# stable content fingerprint for HTTP caching and change detection.
+class TranslationBundle
+  def initialize(namespace:, locale:)
+    @namespace = namespace
+    @locale = locale
+  end
+
+  def to_h
+    published.each_with_object({}) do |translation, tree|
+      insert(tree, translation.translation_key.key.split("."), translation.value)
+    end
+  end
+
+  def to_json(*)
+    JSON.generate(to_h)
+  end
+
+  def etag
+    Digest::SHA256.hexdigest(to_json)
+  end
+
+  private
+    def published
+      Translation.published
+        .where(locale: @locale)
+        .joins(:translation_key)
+        .where(translation_keys: { namespace_id: @namespace.id })
+        .where.not(value: [ nil, "" ])
+        .includes(:translation_key)
+    end
+
+    def insert(tree, segments, value)
+      leaf = segments.pop
+      node = segments.reduce(tree) do |hash, segment|
+        hash[segment] = {} unless hash[segment].is_a?(Hash)
+        hash[segment]
+      end
+      node[leaf] = value
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,17 @@ Rails.application.routes.draw do
     end
   end
 
+  # Public i18n delivery. Mounted under /cdn to avoid any collision with
+  # top-level app routes. namespace may contain dots, so the optional ".json"
+  # suffix (i18next loadPath convention) is stripped in the controller rather
+  # than parsed as a format.
+  get "cdn/:project_slug/:locale/:namespace" => "delivery#show",
+      as: :delivery,
+      format: false,
+      constraints: {
+        locale: /[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*/,
+        namespace: /[a-z0-9][a-z0-9_\-.]*/
+      }
+
   root "projects#index"
 end

--- a/db/migrate/20260628015657_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260628015657_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type, default: -> { "uuidv7()" } do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type, default: -> { "uuidv7()" } do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type, default: -> { "uuidv7()" } do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20260628015800_create_translation_artifacts.rb
+++ b/db/migrate/20260628015800_create_translation_artifacts.rb
@@ -1,0 +1,15 @@
+class CreateTranslationArtifacts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :translation_artifacts, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :project,   null: false, type: :uuid, foreign_key: true
+      t.references :namespace, null: false, type: :uuid, foreign_key: true
+      t.references :locale,    null: false, type: :uuid, foreign_key: true
+      t.string   :checksum, null: false
+      t.datetime :built_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :translation_artifacts, [ :namespace_id, :locale_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_27_120009) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.uuid "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "events", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "action", null: false
@@ -101,6 +129,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_120009) do
     t.index ["translation_id"], name: "index_translation_approvals_on_translation_id", unique: true
   end
 
+  create_table "translation_artifacts", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "built_at", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.uuid "locale_id", null: false
+    t.uuid "namespace_id", null: false
+    t.uuid "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["locale_id"], name: "index_translation_artifacts_on_locale_id"
+    t.index ["namespace_id", "locale_id"], name: "index_translation_artifacts_on_namespace_id_and_locale_id", unique: true
+    t.index ["namespace_id"], name: "index_translation_artifacts_on_namespace_id"
+    t.index ["project_id"], name: "index_translation_artifacts_on_project_id"
+  end
+
   create_table "translation_keys", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "key", null: false
@@ -164,6 +206,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_120009) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "events", "users", column: "creator_id"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "locales", "projects"
@@ -172,6 +216,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_120009) do
   add_foreign_key "sign_in_tokens", "users"
   add_foreign_key "translation_approvals", "translations"
   add_foreign_key "translation_approvals", "users", column: "approver_id"
+  add_foreign_key "translation_artifacts", "locales"
+  add_foreign_key "translation_artifacts", "namespaces"
+  add_foreign_key "translation_artifacts", "projects"
   add_foreign_key "translation_keys", "namespaces"
   add_foreign_key "translation_keys", "projects"
   add_foreign_key "translation_publications", "translations"

--- a/docs/cdn-setup.md
+++ b/docs/cdn-setup.md
@@ -1,0 +1,76 @@
+# CDN setup
+
+The public delivery endpoint is built to sit behind a CDN. The CDN absorbs read
+traffic; the Rails origin only serves cache misses and revalidations.
+
+```
+i18n client ──▶ CDN (edge cache) ──▶ Rails origin  GET /cdn/:slug/:locale/:ns(.json)
+                     │                      │
+                  by URL path        Translation::Artifact (Active Storage blob)
+                                            └─ falls back to compiling live
+```
+
+## Origin contract
+
+`DeliveryController` already emits everything a CDN needs:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Cache-Control` | `public, max-age=3600, stale-while-revalidate=300` | cache 1h at the edge; serve stale up to 5 min while revalidating |
+| `ETag` | content fingerprint (`Translation::Artifact#checksum`) | change detection |
+| `304 Not Modified` | on matching `If-None-Match` | cheap revalidation, empty body |
+
+The `ETag` is derived from the compiled content, so it changes the instant a
+translation is published, unpublished, edited, or deleted. A client (or CDN)
+holding a stale copy gets a new body on its next revalidation.
+
+## Cloudflare configuration
+
+Cache rule (or legacy Page Rule) matching the delivery path:
+
+- **Match:** `*/cdn/*`
+- **Cache eligibility:** Eligible for cache
+- **Edge TTL:** *Use cache-control header from origin* (honors `max-age=3600`)
+- **Browser TTL:** Respect origin
+- **Cache key:** URL path (no cookies, no query — the endpoint takes none)
+- Leave **Respect strong ETags** / origin revalidation on, so `If-None-Match`
+  is forwarded and `304`s are honored.
+
+No Worker is required for caching. `stale-while-revalidate` is honored natively.
+
+## Cache invalidation on publish
+
+Two layers, in order of preference:
+
+1. **Automatic (no action needed).** `stale-while-revalidate=300` means a publish
+   propagates within ~5 minutes everywhere, with no purge call. For most content
+   this is enough.
+
+2. **Instant purge (optional).** For zero-delay propagation, purge the specific
+   URL when a `Translation::Publication` is created or its artifact is rebuilt.
+   The targeted path is deterministic:
+
+   ```
+   https://<delivery-host>/cdn/<project-slug>/<locale-code>/<namespace-name>.json
+   ```
+
+   Cloudflare purge-by-URL:
+
+   ```bash
+   curl -X POST \
+     "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
+     -H "Authorization: Bearer $CF_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"files":["https://cdn.example.com/cdn/demo-app/en/common.json"]}'
+   ```
+
+   The natural trigger is `Translation::Artifact.rebuild` — it runs on exactly
+   the content changes that need a purge. Wiring this as an outbound call belongs
+   with the webhook/delivery-job work (#43): it needs retries, timeouts, and to
+   run off the request path, plus the `CF_ZONE_ID` / `CF_API_TOKEN` secrets. Until
+   then, layer 1 covers propagation.
+
+## Local / development
+
+No CDN. Requests hit Rails directly; the same `Cache-Control`/`ETag` headers
+apply, so behavior matches production minus the edge cache.

--- a/lib/tasks/translations.rake
+++ b/lib/tasks/translations.rake
@@ -1,0 +1,7 @@
+namespace :translations do
+  desc "Rebuild delivery artifacts for every published (namespace, locale)"
+  task rebuild_artifacts: :environment do
+    count = Translation::Artifact.rebuild_all
+    puts "Rebuilt #{count} #{"artifact".pluralize(count)}."
+  end
+end

--- a/test/controllers/translation_keys_controller_test.rb
+++ b/test/controllers/translation_keys_controller_test.rb
@@ -58,4 +58,20 @@ class TranslationKeysControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to project_namespace_path(@project, @namespace)
   end
+
+  test "destroying a published key rebuilds its artifact without the key" do
+    sign_in_as(users(:admin))
+    greeting = translations(:greeting_en) # key "greeting", value "Hello"
+    greeting.publish(by: users(:admin))
+    assert_equal({ "greeting" => "Hello" }, JSON.parse(artifact.file.download))
+
+    delete project_namespace_translation_key_path(@project, @namespace, greeting.translation_key)
+
+    assert_equal({}, JSON.parse(artifact.file.download))
+  end
+
+  private
+    def artifact
+      Translation::Artifact.find_by!(namespace: @namespace, locale: locales(:main_app_en))
+    end
 end

--- a/test/integration/delivery_test.rb
+++ b/test/integration/delivery_test.rb
@@ -35,10 +35,13 @@ class DeliveryTest < ActionDispatch::IntegrationTest
     assert_equal({ "greeting" => "Hello" }, response.parsed_body)
   end
 
-  test "sets a public cache-control and an ETag" do
+  test "sets a CDN-friendly cache-control and an ETag" do
     get cdn_path("common")
     assert_response :success
-    assert_includes response.headers["Cache-Control"], "public"
+    cache_control = response.headers["Cache-Control"]
+    assert_includes cache_control, "public"
+    assert_includes cache_control, "max-age=3600"
+    assert_includes cache_control, "stale-while-revalidate=300"
     assert response.headers["ETag"].present?
   end
 

--- a/test/integration/delivery_test.rb
+++ b/test/integration/delivery_test.rb
@@ -45,11 +45,22 @@ class DeliveryTest < ActionDispatch::IntegrationTest
     assert response.headers["ETag"].present?
   end
 
-  test "returns 304 when the ETag matches" do
+  test "returns 304 with cache headers when the ETag matches" do
     get cdn_path("common")
     etag = response.headers["ETag"]
     get cdn_path("common"), headers: { "If-None-Match" => etag }
     assert_response :not_modified
+    assert_includes response.headers["Cache-Control"], "max-age=3600"
+  end
+
+  test "matches a namespace whose name literally ends in .json" do
+    dotted = @project.namespaces.create!(name: "config.json")
+    key = dotted.translation_keys.create!(project: @project, key: "title")
+    Translation.create!(translation_key: key, locale: @locale, value: "Hi").publish(by: users(:admin))
+
+    get cdn_path("config.json")
+    assert_response :success
+    assert_equal({ "title" => "Hi" }, response.parsed_body)
   end
 
   test "404 for an unknown project" do

--- a/test/integration/delivery_test.rb
+++ b/test/integration/delivery_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class DeliveryTest < ActionDispatch::IntegrationTest
+  setup do
+    @project = projects(:main_app)
+    @locale = locales(:main_app_en)
+    @namespace = namespaces(:main_app_common)
+    translations(:greeting_en).publish(by: users(:admin)) # materializes the artifact
+  end
+
+  test "serves published translations as nested JSON without authentication" do
+    get cdn_path("common")
+    assert_response :success
+    assert_equal "application/json", response.media_type
+    assert_equal({ "greeting" => "Hello" }, response.parsed_body)
+  end
+
+  test "accepts the optional .json suffix" do
+    get cdn_path("common.json")
+    assert_response :success
+    assert_equal({ "greeting" => "Hello" }, response.parsed_body)
+  end
+
+  test "excludes unpublished translations" do
+    translations(:greeting_en).unpublish # rebuilds the artifact without it
+    get cdn_path("common")
+    assert_response :success
+    assert_equal({}, response.parsed_body)
+  end
+
+  test "serves the materialized artifact when present" do
+    assert Translation::Artifact.exists?(namespace: @namespace, locale: @locale)
+    get cdn_path("common")
+    assert_response :success
+    assert_equal({ "greeting" => "Hello" }, response.parsed_body)
+  end
+
+  test "sets a public cache-control and an ETag" do
+    get cdn_path("common")
+    assert_response :success
+    assert_includes response.headers["Cache-Control"], "public"
+    assert response.headers["ETag"].present?
+  end
+
+  test "returns 304 when the ETag matches" do
+    get cdn_path("common")
+    etag = response.headers["ETag"]
+    get cdn_path("common"), headers: { "If-None-Match" => etag }
+    assert_response :not_modified
+  end
+
+  test "404 for an unknown project" do
+    get "/cdn/nope/en/common"
+    assert_response :not_found
+  end
+
+  test "404 for an unknown locale" do
+    get "/cdn/#{@project.slug}/zz/common"
+    assert_response :not_found
+  end
+
+  test "404 for an unknown namespace" do
+    get cdn_path("ghost")
+    assert_response :not_found
+  end
+
+  private
+    def cdn_path(namespace)
+      "/cdn/#{@project.slug}/#{@locale.code}/#{namespace}"
+    end
+end

--- a/test/models/translation/artifact_test.rb
+++ b/test/models/translation/artifact_test.rb
@@ -45,6 +45,16 @@ class Translation::ArtifactTest < ActiveSupport::TestCase
     end
   end
 
+  test "batch rebuilds touched pairs even when the block raises" do
+    assert_raises(RuntimeError) do
+      Translation::Artifact.batch do
+        @translation.publish(by: users(:admin))
+        raise "boom"
+      end
+    end
+    assert Translation::Artifact.exists?(namespace: @namespace, locale: @locale)
+  end
+
   test "destroying the namespace removes its artifacts" do
     @translation.publish(by: users(:admin))
     assert_difference -> { Translation::Artifact.count }, -1 do

--- a/test/models/translation/artifact_test.rb
+++ b/test/models/translation/artifact_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Translation::ArtifactTest < ActiveSupport::TestCase
+  setup do
+    @namespace = namespaces(:main_app_common)
+    @locale = locales(:main_app_en)
+    @translation = translations(:greeting_en) # "Hello"
+  end
+
+  test "publishing materializes an artifact with the compiled file" do
+    assert_difference -> { Translation::Artifact.count }, 1 do
+      @translation.publish(by: users(:admin))
+    end
+    artifact = artifact_for
+    assert artifact.file.attached?
+    assert_equal({ "greeting" => "Hello" }, JSON.parse(artifact.file.download))
+    assert_equal TranslationBundle.new(namespace: @namespace, locale: @locale).etag, artifact.checksum
+  end
+
+  test "unpublishing rebuilds the artifact without the translation" do
+    @translation.publish(by: users(:admin))
+    @translation.unpublish
+    assert_equal({}, JSON.parse(artifact_for.file.download))
+  end
+
+  test "editing a published value rebuilds the artifact" do
+    @translation.publish(by: users(:admin))
+    @translation.update!(value: "Hi", author: users(:admin)) # discards publication
+    assert_equal({}, JSON.parse(artifact_for.file.download))
+  end
+
+  test "batch defers rebuilds and coalesces the same pair into one artifact" do
+    Translation::Artifact.batch do
+      @translation.publish(by: users(:admin))
+      translations(:farewell_en_missing).publish(by: users(:admin)) # same namespace+locale
+      assert_equal 0, Translation::Artifact.count, "rebuild should be deferred until the block exits"
+    end
+    assert_equal 1, Translation::Artifact.count
+  end
+
+  test "rebuild upserts a single artifact per namespace and locale" do
+    Translation::Artifact.rebuild(@namespace.id, @locale.id)
+    assert_no_difference -> { Translation::Artifact.count } do
+      Translation::Artifact.rebuild(@namespace.id, @locale.id)
+    end
+  end
+
+  test "destroying the namespace removes its artifacts" do
+    @translation.publish(by: users(:admin))
+    assert_difference -> { Translation::Artifact.count }, -1 do
+      @namespace.destroy!
+    end
+  end
+
+  test "destroying the locale removes its artifacts" do
+    @translation.publish(by: users(:admin))
+    assert_difference -> { Translation::Artifact.count }, -1 do
+      @locale.destroy!
+    end
+  end
+
+  private
+    def artifact_for
+      Translation::Artifact.find_by!(namespace: @namespace, locale: @locale)
+    end
+end

--- a/test/models/translation_bundle_test.rb
+++ b/test/models/translation_bundle_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class TranslationBundleTest < ActiveSupport::TestCase
+  setup do
+    @namespace = namespaces(:main_app_common)
+    @locale = locales(:main_app_en)
+  end
+
+  test "includes only published translations with a value" do
+    publish translations(:greeting_en) # "Hello"
+    # farewell_en_missing has no value; greeting_pt is another locale
+    assert_equal({ "greeting" => "Hello" }, bundle.to_h)
+  end
+
+  test "excludes unpublished translations" do
+    # greeting_en has a value but no publication
+    assert_equal({}, bundle.to_h)
+  end
+
+  test "expands dotted keys into nested objects" do
+    key = @namespace.translation_keys.create!(project: @namespace.project, key: "home.title")
+    publish Translation.create!(translation_key: key, locale: @locale, value: "Welcome")
+    assert_equal({ "home" => { "title" => "Welcome" } }, bundle.to_h)
+  end
+
+  test "etag changes when content changes" do
+    publish translations(:greeting_en)
+    before = bundle.etag
+    translations(:greeting_en).update!(value: "Hi") # editing unpublishes
+    assert_not_equal before, bundle.etag
+  end
+
+  test "etag is stable for identical content" do
+    publish translations(:greeting_en)
+    assert_equal bundle.etag, bundle.etag
+  end
+
+  private
+    def bundle
+      TranslationBundle.new(namespace: @namespace, locale: @locale)
+    end
+
+    def publish(translation)
+      Translation::Publication.create!(translation: translation, publisher: users(:admin))
+      translation
+    end
+end


### PR DESCRIPTION
## What

Public delivery API that serves a project's published translations as i18n-ready JSON, plus a materialized-artifact cache so the host controls re-fetching.

### Delivery endpoint (#18, #19, #20)
- `GET /cdn/:project_slug/:locale/:namespace(.json)` — public, unauthenticated, matches the i18next http-backend `loadPath` convention.
- Returns the compiled bundle (dotted keys expanded into nested objects), **published translations only**.
- `ETag` + `Cache-Control: public, max-age=300`; conditional `If-None-Match` → `304`.
- Mounted under `/cdn` to avoid collisions; `.json` suffix optional.

### Compilation
- `TranslationBundle` compiles a `(namespace, locale)` into the nested JSON shape (inverse of the JSON import) and exposes a content `etag`.

### Materialized artifacts (Active Storage)
- Each published `(namespace, locale)` is stored as a JSON file via `has_one_attached`.
- Rebuilt **synchronously** whenever its published content changes: publish, unpublish, or an edit that discards a publication.
- Bulk "publish all" coalesces rebuilds via a batch — one compile per affected pair, not per translation.
- Delivery serves the stored blob when present, falling back to compiling live.
- Active Storage tables use uuid keys with the `uuidv7()` default to match the schema.

### Deletion consistency
- Deleting a key rebuilds the surviving namespace's artifacts without it.
- Deleting a locale / namespace / project purges their artifacts (and blobs) via `dependent: :destroy`.

### Ops
- `rake translations:rebuild_artifacts` backfills every published pair (idempotent).

## i18next wiring

```js
i18next.use(HttpBackend).init({
  backend: { loadPath: '/cdn/{{projectSlug}}/{{lng}}/{{ns}}.json' }
})
```

## Tests
220 runs, 683 assertions, 0 failures. Brakeman clean.

Closes #18
Closes #19
Closes #20

Closes #29
