### PR TITLE
feat: API ingestion, cloud backups, configurable delivery + workspace redesign

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,6 @@ group :test do
 end
 
 gem "tailwindcss-rails", "~> 4.6"
+
+# Throttle abusive requests (saveMissing + delivery) [https://github.com/rack/rack-attack]
+gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -400,6 +402,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.3)
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -103,6 +103,7 @@
   input[type="email"],
   input[type="password"],
   input[type="search"],
+  input[type="number"],
   select,
   textarea {
     width: 100%;
@@ -122,6 +123,7 @@
   input[type="email"]:focus,
   input[type="password"]:focus,
   input[type="search"]:focus,
+  input[type="number"]:focus,
   select:focus,
   textarea:focus {
     border-color: var(--color-accent);

--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -1,0 +1,7 @@
+# The signed-in user's sessions. Destroying signs out everywhere but here.
+class Account::SessionsController < ApplicationController
+  def destroy
+    current_user.sessions.where.not(id: Current.session.id).destroy_all
+    redirect_to account_path, notice: "Signed out of all other sessions."
+  end
+end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,0 +1,7 @@
+# The signed-in user's own account: profile + active sessions. Auth is
+# passwordless (magic link), so there's no password to manage here.
+class AccountController < ApplicationController
+  def show
+    @sessions = current_user.sessions.order(created_at: :desc)
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,39 @@
+module Api
+  # Base for all JSON API endpoints. Authenticates a per-project bearer token
+  # (see ApiToken) resolved from the `:project_slug` URL segment. Unlike the web
+  # controllers it does not use cookie sessions or CSRF.
+  class BaseController < ActionController::API
+    before_action :authenticate_api_token!
+
+    private
+      def authenticate_api_token!
+        @project = Project.find_by(slug: params[:project_slug])
+        return render_error(:not_found, "Project not found") if @project.nil?
+
+        @api_token = ApiToken.authenticate(bearer_token, project: @project)
+        return render_error(:unauthorized, "Invalid or missing API token") if @api_token.nil?
+
+        Current.api_token = @api_token
+        @api_token.touch_last_used!
+      end
+
+      def bearer_token
+        header = request.authorization
+        return unless header&.start_with?("Bearer ")
+
+        header.split(" ", 2).last
+      end
+
+      # An `admin` token satisfies every scope.
+      def require_scope!(*scopes)
+        allowed = scopes.map(&:to_s)
+        return if allowed.include?(@api_token.scope) || @api_token.scope == "admin"
+
+        render_error(:forbidden, "Token lacks the required scope")
+      end
+
+      def render_error(status, message)
+        render json: { error: message }, status: status
+      end
+  end
+end

--- a/app/controllers/api/v1/missing_translations_controller.rb
+++ b/app/controllers/api/v1/missing_translations_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module V1
+    # Receives an i18next `saveMissing` payload and records each unknown key in
+    # the project's missing-key triage inbox (MissingKeyReport) — bumping hit
+    # counts and the locales that requested it. It does NOT create real keys;
+    # an editor promotes reports from the Missing tab. Idempotent: replaying a
+    # payload just increments hits.
+    #
+    #   POST /api/v1/projects/:project_slug/missing
+    #   { "locale": "en", "namespace": "common",
+    #     "keys": { "home.title": "Welcome", "nav.signup": "Sign up" } }
+    class MissingTranslationsController < Api::BaseController
+      before_action -> { require_scope!(:save_missing) }
+
+      MAX_KEYS_PER_REQUEST = 500
+
+      def create
+        keys = params[:keys]
+        return render_error(:unprocessable_entity, "keys must be a non-empty object") unless keys.is_a?(ActionController::Parameters) && keys.keys.any?
+        return render_error(:unprocessable_entity, "too many keys (max #{MAX_KEYS_PER_REQUEST})") if keys.keys.size > MAX_KEYS_PER_REQUEST
+        return render_error(:unprocessable_entity, "locale is required")    if params[:locale].blank?
+        return render_error(:unprocessable_entity, "namespace is required") if params[:namespace].blank?
+
+        keys.keys.each do |key_path|
+          MissingKeyReport.record!(project: @project, namespace: params[:namespace], key: key_path, locale: params[:locale])
+        end
+
+        render json: { status: "ok", reported: keys.keys.size }
+      rescue ActiveRecord::RecordInvalid => e
+        render_error(:unprocessable_entity, e.message)
+      end
+    end
+  end
+end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,0 +1,35 @@
+# Workspace members — the Users with access. Admin-only management: change a
+# member's role or remove them. (Single-tenant: every user is a workspace member.)
+class MembersController < ApplicationController
+  before_action :require_admin
+
+  def index
+    @members = User.order(:email)
+  end
+
+  def update
+    user = User.find(params[:id])
+    if user == current_user
+      redirect_to members_path, alert: "You can't change your own role."
+    elsif user.update(member_params)
+      redirect_to members_path, notice: "Updated #{user.email}."
+    else
+      redirect_to members_path, alert: user.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    return redirect_to members_path, alert: "You can't remove yourself." if user == current_user
+
+    user.destroy
+    redirect_to members_path, notice: "Removed #{user.email}."
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to members_path, alert: "#{user.email} has authored content and can't be removed."
+  end
+
+  private
+    def member_params
+      params.expect(user: %i[ role ])
+    end
+end

--- a/app/controllers/projects/api_tokens_controller.rb
+++ b/app/controllers/projects/api_tokens_controller.rb
@@ -1,0 +1,29 @@
+class Projects::ApiTokensController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_administer_project
+
+  def create
+    _record, raw = ApiToken.generate(
+      project: @project,
+      name:    token_params[:name].presence || "API token",
+      scope:   token_params[:scope].presence || "save_missing",
+      creator: current_user
+    )
+    # The raw token is shown exactly once, via flash, on the settings page.
+    redirect_to project_settings_path(@project),
+                flash: { token_created: raw, notice: "API token created — copy it now, it won't be shown again." }
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to project_settings_path(@project), alert: e.message
+  end
+
+  def destroy
+    @project.api_tokens.find(params[:id]).update!(revoked_at: Time.current)
+    redirect_to project_settings_path(@project), notice: "API token revoked."
+  end
+
+  private
+    def token_params
+      params.expect(api_token: %i[ name scope ])
+    end
+end

--- a/app/controllers/projects/backup_schedules_controller.rb
+++ b/app/controllers/projects/backup_schedules_controller.rb
@@ -1,0 +1,19 @@
+# A project's automatic-backup schedule (frequency, retention, drafts).
+class Projects::BackupSchedulesController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_administer_project
+
+  def update
+    if @project.update(schedule_params)
+      redirect_to project_backups_path(@project), notice: "Backup schedule saved."
+    else
+      redirect_to project_backups_path(@project), alert: @project.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+    def schedule_params
+      params.expect(project: %i[ backups_enabled backup_frequency backup_retention backup_include_drafts ])
+    end
+end

--- a/app/controllers/projects/backups/restorations_controller.rb
+++ b/app/controllers/projects/backups/restorations_controller.rb
@@ -1,0 +1,20 @@
+# Restore a project's translations from one of its backups.
+class Projects::Backups::RestorationsController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_administer_project
+
+  def create
+    backup = @project.backups.find(params[:backup_id])
+    raw = backup.file.download
+
+    if backup.checksum.present? && Digest::SHA256.hexdigest(raw) != backup.checksum
+      return redirect_to project_backups_path(@project), alert: "Backup integrity check failed — the snapshot may be corrupted."
+    end
+
+    count = TranslationSnapshot.restore(@project, JSON.parse(raw))
+    redirect_to project_backups_path(@project), notice: "Restored #{count} #{"translation".pluralize(count)} from backup."
+  rescue JSON::ParserError, TranslationSnapshot::FormatError => e
+    redirect_to project_backups_path(@project), alert: "Could not restore backup: #{e.message}"
+  end
+end

--- a/app/controllers/projects/backups_controller.rb
+++ b/app/controllers/projects/backups_controller.rb
@@ -1,0 +1,20 @@
+class Projects::BackupsController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_administer_project
+
+  def index
+    @backups = @project.backups.recent.limit(30)
+  end
+
+  # Back up now — runs synchronously so the new snapshot is visible immediately.
+  def create
+    BackupProjectJob.perform_now(@project, source: "manual")
+    redirect_to project_backups_path(@project), notice: "Backup created."
+  end
+
+  def destroy
+    @project.backups.find(params[:id]).destroy
+    redirect_to project_backups_path(@project), notice: "Backup deleted."
+  end
+end

--- a/app/controllers/projects/missing/promotions_controller.rb
+++ b/app/controllers/projects/missing/promotions_controller.rb
@@ -1,0 +1,12 @@
+# Promote a reported missing key into a real translation key.
+class Projects::Missing::PromotionsController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_edit_translations
+
+  def create
+    report = @project.missing_key_reports.find(params[:missing_id])
+    translation_key = report.promote!(author: current_user)
+    redirect_to project_missing_index_path(@project), notice: "Created key #{translation_key.key}."
+  end
+end

--- a/app/controllers/projects/missing_controller.rb
+++ b/app/controllers/projects/missing_controller.rb
@@ -1,0 +1,15 @@
+class Projects::MissingController < ApplicationController
+  include ProjectScoped
+
+  before_action :ensure_can_edit_translations, only: :destroy
+
+  def index
+    @reports = @project.missing_key_reports.recent
+  end
+
+  # Ignore (dismiss) a reported key.
+  def destroy
+    @project.missing_key_reports.find(params[:id]).destroy
+    redirect_to project_missing_index_path(@project), notice: "Report ignored."
+  end
+end

--- a/app/controllers/projects/settings_controller.rb
+++ b/app/controllers/projects/settings_controller.rb
@@ -6,5 +6,6 @@ class Projects::SettingsController < ApplicationController
   def show
     @locales = @project.locales.alphabetically
     @namespaces = @project.namespaces.alphabetically
+    @api_tokens = @project.api_tokens.active.order(created_at: :desc)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -35,6 +35,8 @@ class ProjectsController < ApplicationController
 
   def update
     if @project.update(project_params)
+      # A new path template re-keys every artifact (purging old blobs).
+      @project.rematerialize_delivery! if @project.saved_change_to_delivery_path_template?
       redirect_to @project, notice: "Project updated."
     else
       render :edit, status: :unprocessable_entity
@@ -52,7 +54,7 @@ class ProjectsController < ApplicationController
     end
 
     def project_params
-      params.expect(project: %i[ name ])
+      params.expect(project: %i[ name missing_rate_limit delivery_rate_limit delivery_path_template ])
     end
 
     def ensure_can_administer_project

--- a/app/controllers/storage_connections/defaults_controller.rb
+++ b/app/controllers/storage_connections/defaults_controller.rb
@@ -1,0 +1,9 @@
+# Set a storage connection as the workspace default.
+class StorageConnections::DefaultsController < ApplicationController
+  before_action :require_admin
+
+  def create
+    StorageConnection.find(params[:storage_connection_id]).update!(is_default: true)
+    redirect_to workspace_path, notice: "Default storage updated."
+  end
+end

--- a/app/controllers/storage_connections_controller.rb
+++ b/app/controllers/storage_connections_controller.rb
@@ -1,0 +1,23 @@
+class StorageConnectionsController < ApplicationController
+  before_action :require_admin
+
+  def create
+    connection = StorageConnection.new(connection_params)
+    connection.is_default = true if StorageConnection.none? # first one is the default
+    if connection.save
+      redirect_to workspace_path, notice: "Storage connection added."
+    else
+      redirect_to workspace_path, alert: connection.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    StorageConnection.find(params[:id]).destroy
+    redirect_to workspace_path, notice: "Storage connection removed."
+  end
+
+  private
+    def connection_params
+      params.expect(storage_connection: %i[ name service_name bucket region ])
+    end
+end

--- a/app/controllers/workspace_controller.rb
+++ b/app/controllers/workspace_controller.rb
@@ -1,0 +1,29 @@
+# Global, admin-only workspace settings (rate-limit defaults). Top-level, not
+# project-scoped. Per-project overrides live in Projects::SettingsController.
+class WorkspaceController < ApplicationController
+  before_action :require_admin
+
+  def show
+    @setting = Setting.current
+    @storage_connections = StorageConnection.ordered
+    @available_services = StorageConnection.available_services
+  end
+
+  def update
+    @setting = Setting.current
+    if @setting.update(setting_params)
+      redirect_to workspace_path, notice: "Workspace settings saved."
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def setting_params
+      params.expect(setting: %i[
+        rate_limiting_enabled
+        missing_rate_limit missing_rate_period
+        delivery_rate_limit delivery_rate_period
+      ])
+    end
+end

--- a/app/javascript/controllers/delivery_preview_controller.js
+++ b/app/javascript/controllers/delivery_preview_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Live preview of the delivery path template. As the operator edits the
+// template, render the resulting object keys for a few sample (namespace,
+// locale) pairs supplied via the `samples` value.
+export default class extends Controller {
+  static targets = ["input", "output"]
+  static values = { samples: Array }
+
+  connect() {
+    this.render()
+  }
+
+  render() {
+    const template = this.inputTarget.value
+    this.outputTarget.innerHTML = ""
+
+    for (const s of this.samplesValue) {
+      const key = template
+        .replaceAll("{project_slug}", s.project_slug)
+        .replaceAll("{namespace}", s.namespace)
+        .replaceAll("{locale}", s.locale)
+
+      const row = document.createElement("div")
+      row.className = "font-mono text-[12px] text-ink-3 truncate"
+      row.textContent = key
+      this.outputTarget.appendChild(row)
+    }
+  }
+}

--- a/app/jobs/backup_all_projects_job.rb
+++ b/app/jobs/backup_all_projects_job.rb
@@ -1,0 +1,11 @@
+# Fan out a per-project backup. Wired to a recurring schedule (config/recurring.yml)
+# so every project is snapshotted to the cloud periodically.
+class BackupAllProjectsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Project.where(backups_enabled: true).find_each do |project|
+      BackupProjectJob.perform_later(project, source: "auto") if project.backup_due?
+    end
+  end
+end

--- a/app/jobs/backup_project_job.rb
+++ b/app/jobs/backup_project_job.rb
@@ -1,0 +1,14 @@
+require "net/http"
+
+# Snapshot one project's translations to the configured storage. The work lives
+# on Project#create_backup!; the job just invokes it and retries transient
+# storage/network failures (cloud uploads).
+class BackupProjectJob < ApplicationJob
+  queue_as :default
+
+  retry_on Net::OpenTimeout, Net::ReadTimeout, wait: :polynomially_longer, attempts: 5
+
+  def perform(project, source: "manual")
+    project.create_backup!(source: source)
+  end
+end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,45 @@
+require "digest"
+
+# Per-project bearer token for client SDKs (i18next saveMissing, future write
+# APIs). Only the SHA-256 digest is stored — the raw token is shown to the user
+# exactly once at creation and is never recoverable afterward.
+class ApiToken < ApplicationRecord
+  SCOPES = %w[ save_missing read_only admin ].freeze
+
+  belongs_to :project
+  belongs_to :creator, class_name: "User", optional: true
+
+  validates :name, presence: true
+  validates :token_digest, presence: true, uniqueness: true
+  validates :scope, presence: true, inclusion: { in: SCOPES }
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  # Build a token, returning [record, raw_token]. Persist the digest; hand the
+  # caller the raw value to display once.
+  def self.generate(project:, name:, scope:, creator: Current.user)
+    raw = SecureRandom.urlsafe_base64(27) # ~36 url-safe chars
+    record = create!(project:, name:, scope:, creator:, token_digest: digest(raw))
+    [ record, raw ]
+  end
+
+  # Resolve an active token for a raw value within a project. Returns nil on a
+  # blank/invalid/revoked token or a project mismatch.
+  def self.authenticate(raw, project:)
+    return if raw.blank? || project.nil?
+
+    active.find_by(project_id: project.id, token_digest: digest(raw))
+  end
+
+  def self.digest(raw)
+    Digest::SHA256.hexdigest(raw.to_s)
+  end
+
+  def revoked?
+    revoked_at.present?
+  end
+
+  def touch_last_used!
+    update_column(:last_used_at, Time.current)
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -2,6 +2,7 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :session
   attribute :user_agent, :ip_address
   attribute :artifact_rebuild_batch
+  attribute :api_token
 
   def user
     session&.user

--- a/app/models/missing_key_report.rb
+++ b/app/models/missing_key_report.rb
@@ -1,0 +1,49 @@
+# A runtime "missing key" reported by an i18next client via saveMissing. Rather
+# than auto-creating keys (which would pollute the keyspace), reports land in a
+# per-project triage inbox: each accumulates hit counts and the locales that
+# requested it. From the Missing tab an editor either promotes a report to a real
+# key or ignores it.
+class MissingKeyReport < ApplicationRecord
+  belongs_to :project
+
+  validates :namespace, presence: true, length: { maximum: 255 }
+  validates :key, presence: true, length: { maximum: 1024 }
+
+  scope :recent, -> { order(last_reported_at: :desc) }
+
+  # Record one runtime miss: bump the hit counter, union in the locale, stamp the
+  # time. Upsert keyed on (project, namespace, key); retries on a concurrent
+  # insert. The counter bump + locale union run as a single atomic SQL UPDATE so
+  # concurrent reports of the same key can't lose increments (read-modify-write
+  # would).
+  def self.record!(project:, namespace:, key:, locale:)
+    report = find_or_create_by!(project: project, namespace: namespace, key: key) do |r|
+      r.first_reported_at = Time.current
+    end
+
+    where(id: report.id).update_all(sanitize_sql_array([
+      "hits = hits + 1, last_reported_at = ?, " \
+      "locales = CASE WHEN locales @> ?::jsonb THEN locales ELSE locales || ?::jsonb END",
+      Time.current, [ locale ].to_json, [ locale ].to_json
+    ]))
+    report
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  # Promote to a real key: create the namespace, the reported locales, the key,
+  # and an empty (missing) translation per locale, then drop the report.
+  def promote!(author: Current.user)
+    translation_key = nil
+    transaction do
+      namespace_record = project.namespaces.find_or_create_by!(name: namespace)
+      translation_key = project.translation_keys.find_or_create_by!(namespace: namespace_record, key: key)
+      locales.each do |code|
+        locale = project.locales.find_or_create_by!(code: code)
+        translation_key.set_translation(locale: locale, value: nil, author: author) unless translation_key.translations.exists?(locale: locale)
+      end
+      destroy!
+    end
+    translation_key
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,11 @@
 class Project < ApplicationRecord
   include Eventable
 
+  # Tokens allowed in delivery_path_template (see #delivery_key_for).
+  DELIVERY_TOKENS = %w[ project_slug namespace locale ].freeze
+
+  BACKUP_FREQUENCIES = %w[ daily weekly monthly ].freeze
+
   before_validation :generate_slug, on: :create
 
   has_many :namespaces, dependent: :restrict_with_exception
@@ -8,13 +13,72 @@ class Project < ApplicationRecord
   has_many :translation_keys, dependent: :destroy
   has_many :translations, dependent: :destroy
   has_many :translation_artifacts, class_name: "Translation::Artifact", dependent: :destroy
+  has_many :api_tokens, dependent: :destroy
+  has_many :backups, class_name: "Project::Backup", dependent: :destroy
+  has_many :missing_key_reports, dependent: :destroy
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
+  validates :delivery_path_template, presence: true
+  validate :delivery_path_template_well_formed
+  validates :backup_frequency, inclusion: { in: BACKUP_FREQUENCIES }
+  validates :backup_retention, numericality: { only_integer: true, greater_than: 0 }
 
   scope :alphabetically, -> { order(name: :asc) }
 
   def to_param = slug
+
+  # Per-IP rate limits, falling back to the global Setting when no override set.
+  def effective_missing_limit  = missing_rate_limit  || Setting.current.missing_rate_limit
+  def effective_delivery_limit = delivery_rate_limit || Setting.current.delivery_rate_limit
+
+  # Deterministic Active Storage object key for a materialized (namespace, locale)
+  # artifact, rendered from delivery_path_template. Lets a self-hoster point a CDN
+  # origin at a stable, readable path in their own bucket. See issue #77 / docs/delivery-paths.md.
+  def delivery_key_for(namespace, locale)
+    delivery_path_template
+      .gsub("{project_slug}", slug)
+      .gsub("{namespace}", namespace.name)
+      .gsub("{locale}", locale.code)
+  end
+
+  # How long between automatic snapshots, per backup_frequency.
+  def backup_interval
+    { "daily" => 1.day, "weekly" => 1.week, "monthly" => 1.month }.fetch(backup_frequency, 1.day)
+  end
+
+  # Is an automatic backup due? (enabled, and none taken within the interval)
+  def backup_due?
+    return false unless backups_enabled
+
+    last = backups.maximum(:created_at)
+    last.nil? || last <= backup_interval.ago
+  end
+
+  # Snapshot this project's translations to the configured storage and prune old
+  # backups. Returns the Project::Backup (or nil if an auto backup was skipped
+  # because nothing changed). Invoked by BackupProjectJob — kept here so the job
+  # stays shallow and the behavior lives with the domain.
+  def create_backup!(source: "manual")
+    json = JSON.pretty_generate(TranslationSnapshot.build(self, include_drafts: backup_include_drafts))
+    checksum = Digest::SHA256.hexdigest(json)
+    return if source == "auto" && backups.recent.first&.checksum == checksum
+
+    backup = backups.create!(source: source, checksum: checksum, translations_count: translations.count, byte_size: json.bytesize)
+    backup.file.attach(**backup_attach_options(backup, json))
+    backups.recent.offset(backup_retention).destroy_all # retention
+    backup
+  end
+
+  # Re-materialize every published (namespace, locale) for this project at the
+  # current template (purging blobs at any previous keys). Returns the count.
+  # Synchronous for now — heavy instances should move this to a job (issue #43).
+  def rematerialize_delivery!
+    pairs = translations.published.joins(:translation_key)
+              .distinct.pluck("translation_keys.namespace_id", :locale_id)
+    pairs.each { |namespace_id, locale_id| Translation::Artifact.rebuild(namespace_id, locale_id) }
+    pairs.size
+  end
 
   # locale_id => percent of keys translated (non-blank value) for this project.
   def locale_coverage
@@ -55,6 +119,41 @@ class Project < ApplicationRecord
   end
 
   private
+    def backup_attach_options(backup, json)
+      options = {
+        io: StringIO.new(json),
+        key: "backups/#{slug}/#{backup.created_at.utc.strftime('%Y%m%d-%H%M%S')}-#{backup.id}.json",
+        filename: "#{slug}.json",
+        content_type: "application/json"
+      }
+      # Route to the workspace's default storage connection when one is set (and
+      # its service is still registered).
+      if (service_name = StorageConnection.default_service_name)
+        options[:service_name] = service_name
+      end
+      options
+    end
+
+    # Template must: render a relative key (no leading "/"), use only known
+    # tokens, include {namespace} and {locale} (so each pair gets a unique key),
+    # and contain only path-safe literal characters.
+    def delivery_path_template_well_formed
+      template = delivery_path_template.to_s
+      return if template.blank?
+
+      errors.add(:delivery_path_template, "must not start with /") if template.start_with?("/")
+
+      template.scan(/\{(\w+)\}/).flatten.uniq.each do |token|
+        errors.add(:delivery_path_template, "has unknown token {#{token}}") unless DELIVERY_TOKENS.include?(token)
+      end
+
+      errors.add(:delivery_path_template, "must include {namespace}") unless template.include?("{namespace}")
+      errors.add(:delivery_path_template, "must include {locale}")    unless template.include?("{locale}")
+
+      literal = template.gsub(/\{\w+\}/, "")
+      errors.add(:delivery_path_template, "has invalid characters") unless literal.match?(%r{\A[A-Za-z0-9/_\-.]*\z})
+    end
+
     def generate_slug
       return if slug.present? || name.blank?
 

--- a/app/models/project/backup.rb
+++ b/app/models/project/backup.rb
@@ -1,0 +1,13 @@
+# One cloud backup of a project's translations: a JSON snapshot stored in the
+# configured Active Storage service (S3/GCS when set, Disk otherwise). Created on
+# demand or by the scheduled BackupProjectJob; oldest beyond KEEP are pruned.
+class Project::Backup < ApplicationRecord
+  self.table_name = "project_backups"
+
+  belongs_to :project
+
+  # The snapshot file; purged with the record.
+  has_one_attached :file
+
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,21 @@
+# Single-row global application settings (rate-limit defaults). Reached only
+# through `Setting.current`, which caches the row so request-path readers (e.g.
+# Rack::Attack) don't hit the database on every request. Saving busts the cache.
+class Setting < ApplicationRecord
+  CACHE_KEY = "app_setting".freeze
+
+  after_commit :reset_cache
+
+  def self.current
+    Rails.cache.fetch(CACHE_KEY) { first || create! }
+  end
+
+  def self.reset_cache
+    Rails.cache.delete(CACHE_KEY)
+  end
+
+  private
+    def reset_cache
+      self.class.reset_cache
+    end
+end

--- a/app/models/storage_connection.rb
+++ b/app/models/storage_connection.rb
@@ -1,0 +1,55 @@
+# A workspace-level, named reference to an Active Storage service (defined in
+# config/storage.yml). Backups (and future uploads) are written to the default
+# connection's service. Credentials are NOT stored here — they come from the
+# service config / environment (IAM role, ENV), the secure self-host path.
+class StorageConnection < ApplicationRecord
+  validates :name, presence: true
+  validates :service_name, presence: true,
+                           inclusion: { in: ->(_record) { available_services }, message: "is not a configured storage service" }
+
+  scope :ordered, -> { order(:name) }
+
+  after_save :unset_other_defaults, if: :is_default?
+
+  # Service names configured in config/storage.yml (e.g. local, amazon, google).
+  # storage.yml is keyed by service name (not by environment), so it's parsed
+  # directly — rendering ERB first since it interpolates Rails.root / credentials.
+  # Memoized: storage.yml is static for the life of the process.
+  def self.available_services
+    @available_services ||= begin
+      path = Rails.root.join("config/storage.yml")
+      if File.exist?(path)
+        rendered = ERB.new(File.read(path)).result
+        (YAML.safe_load(rendered, aliases: true) || {}).keys.map(&:to_s)
+      else
+        []
+      end
+    end
+  rescue StandardError
+    []
+  end
+
+  def self.default
+    find_by(is_default: true)
+  end
+
+  # The default connection's service name, but only when that service is still
+  # registered in Active Storage. Returns nil (use the app default) if the
+  # operator removed the service from storage.yml, so backups don't fail.
+  def self.default_service_name
+    connection = default or return
+    return connection.service_name if available_services.include?(connection.service_name)
+
+    Rails.logger.warn("[StorageConnection] default service #{connection.service_name.inspect} is not configured; using the app default")
+    nil
+  end
+
+  def summary
+    [ bucket.presence, region.presence ].compact.join(" · ").presence || service_name
+  end
+
+  private
+    def unset_other_defaults
+      StorageConnection.where.not(id: id).update_all(is_default: false)
+    end
+end

--- a/app/models/translation/artifact.rb
+++ b/app/models/translation/artifact.rb
@@ -53,22 +53,55 @@ class Translation::Artifact < ApplicationRecord
       namespace = Namespace.find(namespace_id)
       locale = Locale.find(locale_id)
       content = TranslationBundle.new(namespace: namespace, locale: locale)
+      key = namespace.project.delivery_key_for(namespace, locale)
 
-      artifact = find_or_initialize_by(namespace: namespace, locale: locale)
-      artifact.update!(project: namespace.project, checksum: content.etag, built_at: Time.current)
-      artifact.file.attach(
-        io: StringIO.new(content.to_json),
-        filename: "#{locale.code}.json",
-        content_type: "application/json"
-      )
+      artifact = upsert(namespace, locale, content)
+      write_blob(artifact, key, locale, content.to_json)
+      # Advance the served checksum/ETag only AFTER the blob is durably written,
+      # so a failed upload never leaves the row pointing past its stored content.
+      artifact.update!(checksum: content.etag, built_at: Time.current)
       artifact
-    rescue ActiveRecord::RecordNotUnique
-      # A concurrent rebuild inserted the row first; retry so find_or_initialize
-      # takes the update path instead of a colliding insert.
-      retry
+    rescue ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey
+      # The namespace or locale was deleted concurrently (e.g. mid cascade);
+      # there's nothing left to materialize for this pair.
+      nil
     end
 
     private
+      def upsert(namespace, locale, content)
+        artifact = find_or_initialize_by(namespace: namespace, locale: locale)
+        artifact.project = namespace.project
+        # New rows need a checksum (NOT NULL); existing rows keep their current
+        # one until the blob is durably re-written (see rebuild).
+        artifact.checksum ||= content.etag
+        artifact.built_at ||= Time.current
+        artifact.save!
+        artifact
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent rebuild inserted the row first; retry so find_or_initialize
+        # takes the update path instead of a colliding insert.
+        retry
+      end
+
+      # Materialize the JSON at a deterministic key (issue #77). When the key is
+      # unchanged (a content edit), overwrite the existing blob in place — reusing
+      # the same key without the attach+purge churn that would otherwise delete the
+      # object we just wrote. When the key changed (template edit), purge the old
+      # blob and attach a fresh one at the new path.
+      def write_blob(artifact, key, locale, json)
+        io = StringIO.new(json)
+
+        if artifact.file.attached? && artifact.file.key == key
+          blob = artifact.file.blob
+          blob.upload(io, identify: false)
+          blob.content_type = "application/json"
+          blob.save!
+        else
+          artifact.file.purge if artifact.file.attached?
+          artifact.file.attach(io: io, key: key, filename: "#{locale.code}.json", content_type: "application/json")
+        end
+      end
+
       def batched
         Current.artifact_rebuild_batch
       end

--- a/app/models/translation_snapshot.rb
+++ b/app/models/translation_snapshot.rb
@@ -1,0 +1,79 @@
+# Full-fidelity JSON snapshot of a project's translations — every namespace, key,
+# locale, value and published state. Used by the cloud backup (Project::Backup):
+# `build` serializes, `restore` re-imports. Serialization is lossless enough to
+# reconstruct the translation set; restore is an idempotent upsert (it never
+# deletes keys/translations absent from the snapshot).
+class TranslationSnapshot
+  VERSION = 1
+
+  class FormatError < StandardError; end
+
+  def self.build(project, include_drafts: true)
+    new(project, include_drafts:).build
+  end
+
+  def initialize(project, include_drafts: true)
+    @project = project
+    @include_drafts = include_drafts
+  end
+
+  def build
+    {
+      version: VERSION,
+      created_at: Time.current.utc.iso8601,
+      project: { slug: @project.slug, name: @project.name },
+      locales: @project.locales.order(:code).pluck(:code),
+      namespaces: namespaces_hash
+    }
+  end
+
+  # Re-import a snapshot hash into the project. Returns the count of translations
+  # written. Creates any missing locales/namespaces/keys.
+  def self.restore(project, data)
+    raise FormatError, "unsupported snapshot version #{data["version"].inspect}" unless data.is_a?(Hash) && data["version"] == VERSION
+
+    written = 0
+    locales = {}
+
+    ActiveRecord::Base.transaction do
+      Array(data["locales"]).each { |code| locales[code] = project.locales.find_or_create_by!(code: code) }
+
+      (data["namespaces"] || {}).each do |namespace_name, keys|
+        namespace = project.namespaces.find_or_create_by!(name: namespace_name)
+
+        keys.each do |key_path, entries|
+          translation_key = project.translation_keys.find_or_create_by!(namespace: namespace, key: key_path)
+
+          entries.each do |code, entry|
+            locale = (locales[code] ||= project.locales.find_or_create_by!(code: code))
+            translation = translation_key.set_translation(locale: locale, value: entry["value"])
+            translation.publish if entry["published"] && !translation.published?
+            written += 1
+          end
+        end
+      end
+    end
+
+    written
+  end
+
+  private
+    def namespaces_hash
+      result = {}
+      @project.namespaces.order(:name)
+              .includes(translation_keys: { translations: %i[ locale publication ] }).each do |namespace|
+        keys = {}
+        namespace.translation_keys.sort_by(&:key).each do |translation_key|
+          entries = {}
+          translation_key.translations.each do |translation|
+            next if !@include_drafts && !translation.published?
+
+            entries[translation.locale.code] = { value: translation.value, published: translation.published? }
+          end
+          keys[translation_key.key] = entries
+        end
+        result[namespace.name] = keys
+      end
+      result
+    end
+end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, "Account" %>
+
+<div class="max-w-[720px]">
+  <h1 class="m-0 mb-[18px] text-[18px] font-semibold -tracking-[0.01em] text-ink">Account</h1>
+
+  <%# ---- Profile ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-center gap-[9px] text-[16px] font-semibold text-ink mb-4"><%= mi "person", size: 19, css: "text-ink-3" %>Profile</div>
+    <div class="flex items-center gap-4">
+      <div class="w-[56px] h-[56px] rounded-full bg-accent-soft text-accent flex items-center justify-center font-bold text-[20px] flex-none"><%= initials_for(current_user.email) %></div>
+      <div class="min-w-0">
+        <div class="font-mono text-[14px] text-ink truncate"><%= current_user.email %></div>
+        <div class="flex items-center gap-[8px] mt-[5px]">
+          <span class="text-[12px] text-mut capitalize border border-line rounded-full px-[10px] py-[2px]"><%= current_user.role %></span>
+          <span class="text-[12px] text-mut">member since <%= current_user.created_at.strftime("%b %Y") %></span>
+        </div>
+      </div>
+    </div>
+    <p class="text-[12.5px] text-mut mt-[16px] mb-0">Sign-in is passwordless — a one-time link is emailed to <span class="font-mono text-ink-2"><%= current_user.email %></span>. To change your email, ask an admin to re-invite you.</p>
+  </div>
+
+  <%# ---- Sessions ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5">
+    <div class="flex items-center justify-between gap-4 mb-4">
+      <div class="flex items-center gap-[9px] text-[16px] font-semibold text-ink"><%= mi "devices", size: 19, css: "text-ink-3" %>Active sessions</div>
+      <% if @sessions.size > 1 %>
+        <%= button_to "Sign out other sessions", account_sessions_path, method: :delete, class: "btn-secondary",
+              data: { turbo_confirm: "Sign out of all sessions except this one?" } %>
+      <% end %>
+    </div>
+    <div class="border border-line rounded-[9px] overflow-hidden">
+      <% @sessions.each do |session| %>
+        <div class="flex items-center gap-3 px-4 py-[11px] border-b border-line-3 last:border-b-0">
+          <%= mi "computer", size: 18, css: "text-faint" %>
+          <div class="min-w-0 flex-1">
+            <div class="text-[13px] text-ink truncate"><%= session.user_agent.presence || "Unknown device" %></div>
+            <div class="font-mono text-[11.5px] text-mut mt-[2px]"><%= session.ip_address.presence || "—" %> · <%= time_ago_in_words(session.created_at) %> ago</div>
+          </div>
+          <% if session.id == Current.session.id %>
+            <span class="font-mono text-[10px] text-accent bg-accent-soft rounded-[4px] px-[7px] py-px flex-none">THIS DEVICE</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Invitations" %>
 
 <div class="flex items-baseline gap-3">
-  <h1 class="m-0 text-[20px] font-semibold -tracking-[0.02em] text-ink">Invitations</h1>
+  <h2 class="m-0 text-[18px] font-semibold -tracking-[0.01em] text-ink">Invitations</h2>
   <span class="font-mono text-[12px] text-faint"><%= format("%02d", @invitations.size) %></span>
 </div>
 <p class="mt-[7px] text-[13.5px] text-mut">People you've invited to collaborate on your workspace.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,12 +38,20 @@
           <% end %>
 
           <% if current_user.admin? %>
+            <%= link_to members_path, "aria-current": (nav_active?("members") ? "page" : nil), class: "flex items-center gap-[7px] no-underline transition-colors #{nav_active?("members") ? "text-ink font-semibold pb-[2px] border-b-2 border-accent" : "text-ink-3 hover:text-ink"}" do %>
+              <%= mi "group", size: 18 %><span>Members</span>
+            <% end %>
+
             <% pending_invites = Invitation.pending.count %>
             <%= link_to invitations_path, "aria-current": (nav_active?("invitations") ? "page" : nil), class: "flex items-center gap-[7px] no-underline transition-colors #{nav_active?("invitations") ? "text-ink font-semibold pb-[2px] border-b-2 border-accent" : "text-ink-3 hover:text-ink"}" do %>
               <%= mi "mail", size: 18 %><span>Invitations</span>
               <% if pending_invites.positive? %>
                 <span class="font-mono text-[10px] bg-accent-soft text-accent rounded-full px-[7px] py-px font-semibold"><%= pending_invites %></span>
               <% end %>
+            <% end %>
+
+            <%= link_to workspace_path, "aria-current": (nav_active?("workspace") ? "page" : nil), class: "flex items-center gap-[7px] no-underline transition-colors #{nav_active?("workspace") ? "text-ink font-semibold pb-[2px] border-b-2 border-accent" : "text-ink-3 hover:text-ink"}" do %>
+              <%= mi "corporate_fare", size: 18 %><span>Workspace</span>
             <% end %>
           <% end %>
 
@@ -58,6 +66,14 @@
                 </div>
               </div>
               <div class="p-[5px]">
+                <% if current_user.admin? %>
+                  <%= link_to workspace_path, class: "flex items-center gap-[10px] px-[10px] py-[9px] rounded-[7px] text-[13px] text-ink no-underline hover:bg-surface-2" do %>
+                    <%= mi "corporate_fare", size: 18, css: "text-ink-3" %>Workspace settings
+                  <% end %>
+                <% end %>
+                <%= link_to account_path, class: "flex items-center gap-[10px] px-[10px] py-[9px] rounded-[7px] text-[13px] text-ink no-underline hover:bg-surface-2" do %>
+                  <%= mi "person", size: 18, css: "text-ink-3" %>Account settings
+                <% end %>
                 <%= button_to sign_out_path, method: :delete, class: "w-full flex items-center gap-[10px] px-[10px] py-[9px] rounded-[7px] text-[13px] text-ink hover:bg-surface-2" do %>
                   <%= mi "logout", size: 18, css: "text-ink-3" %>Sign out
                 <% end %>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "Members" %>
+
+<div class="max-w-[920px]">
+  <div class="flex items-center justify-between mb-[6px]">
+    <div class="flex items-baseline gap-3">
+      <h2 class="m-0 text-[18px] font-semibold -tracking-[0.01em] text-ink">Members</h2>
+      <span class="font-mono text-[12px] text-mut"><%= format("%02d", @members.size) %></span>
+    </div>
+    <%= link_to new_invitation_path, class: "btn" do %>
+      <%= mi "person_add", size: 17, css: "mr-[5px]" %>Invite people
+    <% end %>
+  </div>
+  <p class="m-0 mb-5 text-[14px] text-mut">People with access to your Language Bridge workspace.</p>
+
+  <div class="border border-line rounded-[10px] overflow-hidden">
+    <% @members.each do |member| %>
+      <div class="flex items-center justify-between gap-4 px-[18px] py-[14px] border-b border-line-3 last:border-b-0 hover:bg-surface-2">
+        <div class="flex items-center gap-[13px] min-w-0">
+          <div class="w-[36px] h-[36px] rounded-full bg-line-3 text-ink-2 flex items-center justify-center font-semibold text-[14px] flex-none"><%= initials_for(member.email) %></div>
+          <div class="min-w-0">
+            <div class="flex items-center gap-[8px]">
+              <span class="text-[14px] font-semibold text-ink truncate"><%= member.email.split("@").first %></span>
+              <% if member == current_user %><span class="font-mono text-[11px] text-accent bg-accent-soft rounded-[4px] px-[6px] py-px">you</span><% end %>
+            </div>
+            <div class="font-mono text-[12px] text-mut mt-[3px] truncate"><%= member.email %></div>
+          </div>
+        </div>
+        <div class="flex items-center gap-[12px] flex-none">
+          <% if member == current_user %>
+            <span class="text-[13px] text-ink-2 px-1 capitalize"><%= member.role %></span>
+          <% else %>
+            <%= form_with model: member, url: member_path(member), method: :patch, local: true, html: { class: "inline", data: { controller: "auto-submit" } } do |form| %>
+              <%= form.select :role, User::ROLES.map { |r| [ r.titleize, r ] }, {}, class: "!w-auto text-[13px]", data: { action: "change->auto-submit#submit" } %>
+            <% end %>
+            <%= button_to member_path(member), method: :delete, class: "text-[13px] text-mut hover:!text-danger bg-transparent border-0 cursor-pointer",
+                  data: { turbo_confirm: "Remove #{member.email} from the workspace?" } do %>Remove<% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -6,7 +6,7 @@
   <%= link_to project_path(project), class: "block p-[18px] no-underline" do %>
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <div class="text-[15px] font-semibold text-ink -tracking-[0.01em] truncate"><%= project.name %></div>
+        <div class="text-[16px] font-semibold text-ink -tracking-[0.01em] truncate"><%= project.name %></div>
         <div class="font-mono text-[12px] text-faint mt-1"><%= project.slug %></div>
       </div>
       <span class="font-mono text-[11px] text-mut-2 whitespace-nowrap shrink-0"><%= time_ago_in_words(project.updated_at) %> ago</span>

--- a/app/views/projects/_tabs.html.erb
+++ b/app/views/projects/_tabs.html.erb
@@ -8,12 +8,17 @@
   </div>
 
   <nav class="flex items-center gap-[22px] h-full text-[13px] ml-[6px]">
+    <% reported = project.missing_key_reports.count %>
     <% tabs = [
-         { key: :overview, label: "Overview", icon: "dashboard", url: project_path(project) },
+         { key: :overview, label: "Overview", icon: "dashboard",  url: project_path(project) },
          { key: :editor,   label: "Editor",   icon: "table_rows", url: (editor_ns ? project_namespace_path(project, editor_ns) : nil) },
-         { key: :activity, label: "Activity", icon: "history",   url: project_activity_path(project) }
+         { key: :missing,  label: "Missing",  icon: "inbox",      url: project_missing_index_path(project), badge: (reported.positive? ? reported : nil) },
+         { key: :activity, label: "Activity", icon: "history",    url: project_activity_path(project) }
        ] %>
-    <% tabs << { key: :settings, label: "Settings", icon: "settings", url: project_settings_path(project) } if current_user.admin? %>
+    <% if current_user.admin? %>
+      <% tabs << { key: :backups,  label: "Backups",  icon: "backup",   url: project_backups_path(project) } %>
+      <% tabs << { key: :settings, label: "Settings", icon: "settings", url: project_settings_path(project) } %>
+    <% end %>
 
     <% tabs.each do |tab| %>
       <% is_active = active == tab[:key] %>
@@ -21,6 +26,7 @@
         <%= link_to tab[:url], "aria-current": (is_active ? "page" : nil),
               class: "flex items-center h-full no-underline border-b-2 #{is_active ? "text-ink font-semibold border-accent" : "text-ink-3 border-transparent hover:text-ink"}" do %>
           <%= mi tab[:icon], size: 17, css: "mr-[7px]" %><%= tab[:label] %>
+          <% if tab[:badge] %><span class="ml-[7px] font-mono text-[10px] bg-accent-soft text-accent rounded-full px-[7px] py-px font-semibold"><%= tab[:badge] %></span><% end %>
         <% end %>
       <% else %>
         <span class="flex items-center h-full text-faint border-b-2 border-transparent cursor-not-allowed" title="No namespaces yet">

--- a/app/views/projects/activity/show.html.erb
+++ b/app/views/projects/activity/show.html.erb
@@ -5,7 +5,7 @@
 
 <div class="mx-auto w-full max-w-[1320px] px-6 py-7">
   <div class="max-w-[920px]">
-  <h2 class="m-0 text-[17px] font-semibold text-ink">Activity</h2>
+  <h2 class="m-0 text-[18px] font-semibold text-ink">Activity</h2>
   <p class="mt-[7px] mb-5 text-[13.5px] text-mut">Recent changes across <%= @project.name %>.</p>
 
   <% if @events.any? %>

--- a/app/views/projects/backups/index.html.erb
+++ b/app/views/projects/backups/index.html.erb
@@ -1,0 +1,120 @@
+<% content_for :title, "Backups · #{@project.name}" %>
+<% content_for :main_class, "flex-1 w-full flex flex-col min-h-0" %>
+
+<%= render "projects/tabs", project: @project, active: :backups %>
+
+<div class="mx-auto w-full max-w-[1320px] px-6 py-7">
+  <div class="max-w-[920px]">
+
+    <%# ---- Header ---- %>
+    <div class="flex items-start justify-between gap-6 mb-[18px]">
+      <div>
+        <h2 class="m-0 text-[18px] font-semibold text-ink">Backups</h2>
+        <p class="mt-[5px] mb-0 text-[13px] text-mut max-w-[520px] leading-[1.5]">Point-in-time snapshots of every key, locale and translation, stored in your Active Storage bucket. Restore or download any snapshot — automatically, on a schedule you set.</p>
+      </div>
+      <%= button_to project_backups_path(@project), method: :post, class: "btn flex-none" do %>
+        <%= mi "backup", size: 17, css: "mr-[6px]" %>Back up now
+      <% end %>
+    </div>
+
+    <% if StorageConnection.default.nil? %>
+      <div class="border border-banner-border bg-banner-bg rounded-[11px] px-[20px] py-4 mb-5 flex items-start gap-[14px]">
+        <div class="w-[34px] h-[34px] rounded-[9px] bg-draft-border/40 text-banner-ink flex items-center justify-center flex-none"><%= mi "cloud_off", size: 19 %></div>
+        <div class="flex-1 min-w-0">
+          <div class="text-[14px] font-semibold text-ink">Backups use local storage</div>
+          <div class="text-[13px] text-banner-ink mt-[3px] leading-[1.5]">No storage connection is set for this workspace, so snapshots are written to the default Active Storage service. <%= link_to "Connect a bucket", workspace_path, class: "font-semibold underline" %> for durable, off-box backups.</div>
+        </div>
+      </div>
+    <% end %>
+
+    <%# ---- Schedule ---- %>
+    <%= form_with model: @project, url: project_backup_schedule_path(@project), method: :patch, local: true do |form| %>
+      <div class="border border-line rounded-[11px] px-[22px] py-5 mb-5">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "schedule", size: 19, css: "text-ink-3" %>Automatic backups</div>
+            <div class="text-[13px] text-mut mt-[3px]">A snapshot is taken on this schedule and pruned to your retention limit.</div>
+          </div>
+          <label class="flex items-center gap-[9px] cursor-pointer flex-none">
+            <%= form.check_box :backups_enabled, class: "w-[16px] h-[16px]" %>
+            <span class="text-[13px] text-ink-2">Enabled</span>
+          </label>
+        </div>
+
+        <div class="border-t border-line-3 mt-[18px] pt-5 grid grid-cols-1 sm:grid-cols-2 gap-5">
+          <div class="flex flex-col gap-[7px]">
+            <%= form.label :backup_frequency, "Frequency", class: "text-[12.5px] font-medium text-ink-2" %>
+            <%= form.select :backup_frequency, Project::BACKUP_FREQUENCIES.map { |f| [ f.capitalize, f ] }, {}, class: "text-[14px]" %>
+          </div>
+          <div class="flex flex-col gap-[7px]">
+            <%= form.label :backup_retention, "Retention (snapshots to keep)", class: "text-[12.5px] font-medium text-ink-2" %>
+            <%= form.number_field :backup_retention, min: 1, class: "text-[14px]" %>
+          </div>
+        </div>
+
+        <label class="flex items-center gap-[9px] cursor-pointer mt-[18px]">
+          <%= form.check_box :backup_include_drafts, class: "w-[16px] h-[16px]" %>
+          <span class="text-[13px] text-ink-2">Include unpublished drafts <span class="text-mut">— back up draft values alongside the published ones</span></span>
+        </label>
+
+        <div class="flex justify-end mt-[18px]">
+          <%= form.submit "Save schedule", class: "btn" %>
+        </div>
+      </div>
+    <% end %>
+
+    <%# ---- Recent snapshots ---- %>
+    <div class="flex items-baseline justify-between mb-3">
+      <div class="flex items-baseline gap-[11px]">
+        <h3 class="m-0 text-[16px] font-semibold text-ink -tracking-[0.01em]">Recent snapshots</h3>
+        <span class="font-mono text-[12px] text-mut"><%= format("%02d", @backups.size) %></span>
+      </div>
+      <span class="font-mono text-[12px] text-mut">Keep last <%= @project.backup_retention %></span>
+    </div>
+
+    <% if @backups.any? %>
+      <div class="border border-line rounded-[11px] overflow-hidden">
+        <div class="flex items-center px-[18px] py-[9px] bg-surface-2 border-b border-line font-mono text-[11px] tracking-[0.05em] uppercase text-faint">
+          <div class="flex-1 min-w-0">Snapshot</div>
+          <div class="w-[108px] flex-none">Keys</div>
+          <div class="w-[88px] flex-none">Size</div>
+          <div class="w-[210px] flex-none text-right">Actions</div>
+        </div>
+        <% @backups.each do |backup| %>
+          <div class="flex items-center px-[18px] py-[13px] border-b border-line-3 last:border-b-0 hover:bg-surface-2">
+            <div class="flex-1 min-w-0 flex items-center gap-[11px]">
+              <span class="w-[8px] h-[8px] rounded-full bg-ok flex-none" title="Complete"></span>
+              <span class="text-[13px] text-ink font-medium"><%= backup.created_at.strftime("%Y-%m-%d %H:%M") %></span>
+              <% if backup.source == "auto" %>
+                <span class="font-mono text-[10px] tracking-[0.05em] text-ink-2 bg-line-3 rounded px-[7px] py-[2px]">AUTO</span>
+              <% else %>
+                <span class="font-mono text-[10px] tracking-[0.05em] text-accent bg-accent-soft rounded px-[7px] py-[2px]">MANUAL</span>
+              <% end %>
+            </div>
+            <div class="w-[108px] flex-none font-mono text-[12px] text-ink-2"><%= number_with_delimiter(backup.translations_count) %></div>
+            <div class="w-[88px] flex-none font-mono text-[12px] text-ink-2"><%= number_to_human_size(backup.byte_size) %></div>
+            <div class="w-[210px] flex-none flex items-center justify-end gap-[7px]">
+              <% if backup.file.attached? %>
+                <%= link_to rails_blob_path(backup.file, disposition: "attachment"), class: "btn-secondary" do %>
+                  <%= mi "download", size: 15, css: "mr-[5px]" %>Download
+                <% end %>
+              <% end %>
+              <%= button_to project_backup_restoration_path(@project, backup), method: :post, class: "btn-secondary", form_class: "inline",
+                    data: { turbo_confirm: "Restore translations from #{backup.created_at.strftime("%Y-%m-%d %H:%M")}? Existing values will be overwritten." } do %>
+                <%= mi "restore", size: 15, css: "mr-[5px]" %>Restore
+              <% end %>
+              <%= button_to project_backup_path(@project, backup), method: :delete, class: "btn-secondary btn-danger", form_class: "inline",
+                    "aria-label": "Delete backup", data: { turbo_confirm: "Delete this snapshot?" } do %>
+                <%= mi "delete", size: 15 %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="border border-line rounded-[11px] px-[22px] py-10 text-center">
+        <div class="text-[13px] text-mut">No snapshots yet. Use <span class="font-medium text-ink-2">Back up now</span> to create one.</div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/missing/index.html.erb
+++ b/app/views/projects/missing/index.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, "Missing · #{@project.name}" %>
+<% content_for :main_class, "flex-1 w-full flex flex-col min-h-0" %>
+
+<%= render "projects/tabs", project: @project, active: :missing %>
+
+<div class="mx-auto w-full max-w-[1320px] px-6 py-7">
+  <div class="max-w-[920px]">
+
+    <%# ---- Header ---- %>
+    <div class="flex items-start justify-between gap-6 mb-[6px]">
+      <div class="flex items-baseline gap-[11px]">
+        <h2 class="m-0 text-[19px] font-semibold -tracking-[0.02em] text-ink">Missing translations</h2>
+        <span class="font-mono text-[12px] text-mut"><%= @reports.size %> reported</span>
+      </div>
+      <span class="inline-flex items-center gap-[6px] font-mono text-[11px] text-ink-2 bg-line-3 rounded-[6px] px-[10px] py-[5px]">
+        <span class="w-[6px] h-[6px] rounded-full bg-ok"></span>i18next saveMissing · live
+      </span>
+    </div>
+    <p class="m-0 mb-4 text-[13px] text-mut max-w-[620px] leading-[1.5]">Keys your apps requested at runtime that don't exist yet. Reported by the SDK via <span class="font-mono text-ink-2">saveMissing</span> — promote them to real keys or ignore them.</p>
+
+    <div class="flex items-center gap-[10px] px-[14px] py-[11px] border border-line rounded-[9px] bg-surface-2 mb-[18px] font-mono text-[12px] text-ink-2 overflow-x-auto">
+      <span class="text-ok font-semibold">POST</span>
+      <span class="text-ink">/api/v1/projects/<%= @project.slug %>/missing</span>
+      <span class="text-faint">{ locale, namespace, keys }</span>
+    </div>
+
+    <% if @reports.any? %>
+      <div class="border border-line rounded-[11px] overflow-hidden">
+        <div class="flex items-center px-[18px] py-[9px] bg-surface-2 border-b border-line font-mono text-[11px] tracking-[0.05em] uppercase text-faint">
+          <div class="flex-1 min-w-0">Key</div>
+          <div class="w-[150px] flex-none">Locales</div>
+          <div class="w-[80px] flex-none text-right">Hits</div>
+          <div class="w-[96px] flex-none text-right">Last seen</div>
+          <div class="w-[188px] flex-none text-right">Actions</div>
+        </div>
+        <% @reports.each do |report| %>
+          <div class="flex items-center px-[18px] py-[13px] border-b border-line-3 last:border-b-0 hover:bg-surface-2">
+            <div class="flex-1 min-w-0 flex items-center gap-[11px]">
+              <span class="w-[8px] h-[8px] rounded-full border-[1.5px] border-faint-2 flex-none"></span>
+              <div class="min-w-0">
+                <div class="font-mono text-[13px] text-ink break-all leading-[1.5]"><%= report.key %></div>
+                <div class="flex items-center gap-[6px] font-mono text-[11px] text-faint mt-[2px]"><%= mi "folder", size: 13 %><%= report.namespace %></div>
+              </div>
+            </div>
+            <div class="w-[150px] flex-none font-mono text-[12px] text-ink-2 truncate"><%= report.locales.join(", ") %></div>
+            <div class="w-[80px] flex-none text-right font-mono text-[12px] text-ink font-semibold"><%= report.hits %></div>
+            <div class="w-[96px] flex-none text-right font-mono text-[12px] text-mut"><%= report.last_reported_at ? "#{time_ago_in_words(report.last_reported_at)} ago" : "—" %></div>
+            <div class="w-[188px] flex-none flex items-center justify-end gap-[7px]">
+              <% if current_user.can_edit_translations?(@project) %>
+                <%= button_to project_missing_path(@project, report), method: :delete, class: "btn-secondary", form_class: "inline",
+                      data: { turbo_confirm: "Ignore \"#{report.key}\"? It will be removed from the inbox." } do %>Ignore<% end %>
+                <%= button_to project_missing_promotion_path(@project, report), method: :post, class: "btn-secondary", form_class: "inline" do %>
+                  <%= mi "add", size: 15, css: "mr-[5px]" %>Create key
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="border border-dashed border-line rounded-[11px] px-[26px] py-12 flex flex-col items-center text-center bg-surface-2">
+        <div class="w-[48px] h-[48px] border-[1.5px] border-line rounded-[11px] flex items-center justify-center text-faint bg-surface mb-4"><%= mi "inbox", size: 24 %></div>
+        <h3 class="m-0 text-[16px] font-semibold text-ink">Inbox zero</h3>
+        <p class="mt-2 mb-0 text-[14px] text-mut max-w-[360px] leading-[1.5]">No missing keys reported. New keys requested at runtime will show up here automatically.</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/settings/show.html.erb
+++ b/app/views/projects/settings/show.html.erb
@@ -203,7 +203,7 @@
         </div>
       </div>
       <div class="flex justify-end mt-[18px]">
-        <%= form.submit "Save changes", class: "btn" %>
+        <%= form.submit "Save rate limits", class: "btn" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/settings/show.html.erb
+++ b/app/views/projects/settings/show.html.erb
@@ -101,6 +101,111 @@
       <% sample_ns = @project.namespaces.alphabetically.first&.name || "common" %>
       <div><span class="text-[#5e5e5e]">GET</span> <%= request.base_url %>/cdn/<span class="text-[#6bd08f]"><%= @project.slug %></span>/<%= sample_locale %>/<%= sample_ns %></div>
     </div>
+
+    <%# ---- Storage path template (issue #77): deterministic Active Storage key ---- %>
+    <%
+      ns_names  = @namespaces.any? ? @namespaces.first(2).map(&:name) : [ "common" ]
+      loc_codes = @locales.any? ? @locales.first(2).map(&:code) : [ "en" ]
+      delivery_samples = ns_names.product(loc_codes).first(3).map { |n, l| { project_slug: @project.slug, namespace: n, locale: l } }
+    %>
+    <%= form_with model: @project, local: true,
+          data: { controller: "delivery-preview", "delivery-preview-samples-value": delivery_samples.to_json } do |form| %>
+      <% if @project.errors[:delivery_path_template].any? %>
+        <ul class="mt-4 mb-2 text-[13px] text-danger-ink bg-danger-soft border border-danger-border rounded-[9px] px-4 py-3 list-disc list-inside">
+          <% @project.errors[:delivery_path_template].each do |msg| %><li>Path template <%= msg %></li><% end %>
+        </ul>
+      <% end %>
+
+      <label class="block text-[12.5px] font-medium text-ink-2 mt-[18px] mb-[7px]">Storage path template</label>
+      <%= form.text_field :delivery_path_template,
+            data: { "delivery-preview-target": "input", action: "input->delivery-preview#render" },
+            autocomplete: "off", autocapitalize: "none", spellcheck: "false", class: "font-mono text-[13px]" %>
+      <div class="text-[12px] text-mut mt-[7px]">Object key for materialized artifacts in your Active Storage bucket — point a CDN origin at it.
+        Tokens: <code class="font-mono">{project_slug}</code> <code class="font-mono">{namespace}</code> <code class="font-mono">{locale}</code>
+        (must include <code class="font-mono">{namespace}</code> and <code class="font-mono">{locale}</code>).</div>
+
+      <div class="mt-[12px] mb-[6px] text-[12px] font-medium text-ink-2">Resulting paths</div>
+      <div data-delivery-preview-target="output" class="border border-line rounded-[9px] bg-surface-2 px-[14px] py-[10px] flex flex-col gap-[3px]"></div>
+
+      <div class="flex justify-end mt-[14px]">
+        <%= form.submit "Save path template", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# ---- API tokens ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "key", size: 19, css: "text-ink-3" %>API tokens</div>
+    <div class="text-[13px] text-mut mt-[3px] mb-4">Bearer tokens for client SDKs calling the saveMissing API. The raw token is shown once at creation — store it securely.</div>
+
+    <% if flash[:token_created].present? %>
+      <div class="mb-4 border border-accent rounded-[9px] bg-accent-soft px-4 py-3">
+        <div class="text-[12.5px] font-medium text-ink-2 mb-[6px]">New token (copy now — it won't be shown again):</div>
+        <code class="block font-mono text-[12.5px] text-ink break-all"><%= flash[:token_created] %></code>
+      </div>
+    <% end %>
+
+    <% if @api_tokens.any? %>
+      <div class="border border-line rounded-[9px] overflow-hidden mb-4">
+        <% @api_tokens.each do |token| %>
+          <div class="flex items-center gap-2 px-4 py-[10px] border-b border-line-3 last:border-b-0">
+            <%= mi "key", size: 18, css: "text-faint" %>
+            <span class="text-[13px] text-ink truncate min-w-0"><%= token.name %></span>
+            <span class="font-mono text-[11px] text-ink-3 bg-surface-2 rounded px-[6px] py-px"><%= token.scope %></span>
+            <span class="text-[12px] text-mut ml-auto"><%= token.last_used_at ? "used #{time_ago_in_words(token.last_used_at)} ago" : "never used" %></span>
+            <%= button_to project_api_token_path(@project, token), method: :delete, class: "btn-secondary btn-danger", form_class: "inline",
+                  "aria-label": "Revoke token #{token.name}",
+                  data: { turbo_confirm: "Revoke token \"#{token.name}\"? Clients using it will stop working." } do %>
+              <%= mi "delete", size: 16 %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-[13px] text-mut mb-4">No tokens yet.</p>
+    <% end %>
+
+    <%= form_with url: project_api_tokens_path(@project), method: :post, local: true, html: { class: "flex items-end gap-3 flex-wrap" } do %>
+      <div class="flex flex-col gap-[7px]">
+        <label class="text-[12.5px] font-medium text-ink-2">Name</label>
+        <%= text_field_tag "api_token[name]", nil, placeholder: "e.g. Web client", required: true, class: "text-[14px]" %>
+      </div>
+      <div class="flex flex-col gap-[7px]">
+        <label class="text-[12.5px] font-medium text-ink-2">Scope</label>
+        <%= select_tag "api_token[scope]", options_for_select(ApiToken::SCOPES, "save_missing"), class: "text-[14px]" %>
+      </div>
+      <%= submit_tag "Create token", class: "btn" %>
+    <% end %>
+  </div>
+
+  <%# ---- Rate limit override ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "speed", size: 19, css: "text-ink-3" %>Rate limits</div>
+    <div class="text-[13px] text-mut mt-[3px] mb-[18px]">Per-IP request limits for this project. Leave blank to inherit the workspace defaults
+      (saveMissing <%= Setting.current.missing_rate_limit %>/<%= Setting.current.missing_rate_period %>s,
+      delivery <%= Setting.current.delivery_rate_limit %>/<%= Setting.current.delivery_rate_period %>s).</div>
+
+    <%= form_with model: @project, local: true do |form| %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :missing_rate_limit, "saveMissing", class: "text-[12.5px] font-medium text-ink-2" %>
+          <div class="relative">
+            <%= form.number_field :missing_rate_limit, min: 1, placeholder: "#{Setting.current.missing_rate_limit} (inherited)", class: "text-[14px] pr-[66px]" %>
+            <span class="absolute right-[12px] top-1/2 -translate-y-1/2 font-mono text-[11.5px] text-mut pointer-events-none">req/min</span>
+          </div>
+        </div>
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :delivery_rate_limit, "Delivery", class: "text-[12.5px] font-medium text-ink-2" %>
+          <div class="relative">
+            <%= form.number_field :delivery_rate_limit, min: 1, placeholder: "#{Setting.current.delivery_rate_limit} (inherited)", class: "text-[14px] pr-[66px]" %>
+            <span class="absolute right-[12px] top-1/2 -translate-y-1/2 font-mono text-[11.5px] text-mut pointer-events-none">req/min</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex justify-end mt-[18px]">
+        <%= form.submit "Save changes", class: "btn" %>
+      </div>
+    <% end %>
   </div>
 
   <%# ---- Danger zone ---- %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,7 @@
 <%= render "projects/tabs", project: @project, active: :overview %>
 
 <div class="mx-auto w-full max-w-[1320px] px-6 py-7">
-  <h2 class="m-0 mb-[18px] text-[17px] font-semibold text-ink">Overview</h2>
+  <h2 class="m-0 mb-[18px] text-[18px] font-semibold text-ink">Overview</h2>
   <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-[30px]">
     <% [
          { label: "Locales", icon: "language", value: @project.locales_count },

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,7 @@
   <%# ---- left: form ---- %>
   <div class="relative flex items-center justify-center px-10 py-12 bg-surface overflow-hidden">
     <div class="absolute inset-0 pointer-events-none"
-         style="background-image:radial-gradient(#e0e0e0 1px,transparent 1px);background-size:15px 15px;-webkit-mask-image:radial-gradient(circle at 28% 32%, rgba(0,0,0,.6), transparent 62%);mask-image:radial-gradient(circle at 28% 32%, rgba(0,0,0,.6), transparent 62%)"></div>
+         style="background-image:radial-gradient(#e2e8f0 1px,transparent 1px);background-size:15px 15px;-webkit-mask-image:radial-gradient(circle at 28% 32%, rgba(0,0,0,.6), transparent 62%);mask-image:radial-gradient(circle at 28% 32%, rgba(0,0,0,.6), transparent 62%)"></div>
 
     <div class="relative w-[300px]">
       <div class="flex justify-center mb-[22px]">
@@ -35,7 +35,7 @@
 
   <%# ---- right: testimonial ---- %>
   <div class="relative hidden md:block bg-slate-900 overflow-hidden">
-    <div class="absolute inset-0" style="background:repeating-linear-gradient(135deg,#1f1f1f,#1f1f1f 13px,#242424 13px,#242424 26px)"></div>
+    <div class="absolute inset-0" style="background:repeating-linear-gradient(135deg,#0f172a,#0f172a 13px,#1e293b 13px,#1e293b 26px)"></div>
     <div class="absolute inset-0" style="background:linear-gradient(to top, rgba(0,0,0,.72), transparent 55%)"></div>
     <div class="absolute left-0 right-0 bottom-0 p-11">
       <p class="m-0 text-[22px] leading-[1.42] font-medium -tracking-[0.01em] text-white text-center">“We shipped in 14 languages without a single spreadsheet.”</p>

--- a/app/views/workspace/show.html.erb
+++ b/app/views/workspace/show.html.erb
@@ -1,0 +1,108 @@
+<% content_for :title, "Workspace" %>
+
+<div class="max-w-[920px]">
+  <h2 class="m-0 mb-[4px] text-[18px] font-semibold text-ink">Workspace settings</h2>
+  <p class="text-[13px] text-mut mb-5">Shared infrastructure — applies to every project in your workspace.</p>
+
+  <%# ---- Storage connections ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <div>
+        <div class="flex items-center gap-[9px] text-[16px] font-semibold text-ink"><%= mi "cloud_upload", size: 19, css: "text-ink-3" %>Storage connections</div>
+        <div class="text-[13px] text-mut mt-[3px]">Active Storage buckets where backups and uploads live. Credentials come from your environment / IAM role — none are stored here.</div>
+      </div>
+    </div>
+
+    <% if @storage_connections.any? %>
+      <div class="border border-line rounded-[9px] overflow-hidden mb-4">
+        <% @storage_connections.each do |connection| %>
+          <div class="flex items-center justify-between gap-3 px-4 py-[13px] border-b border-line-3 last:border-b-0 hover:bg-surface-2">
+            <div class="flex items-center gap-3 min-w-0">
+              <div class="w-[34px] h-[34px] rounded-[8px] bg-surface-2 flex items-center justify-center flex-none"><%= mi "database", size: 18, css: "text-ink-2" %></div>
+              <div class="min-w-0">
+                <div class="flex items-center gap-2">
+                  <span class="text-[14px] font-semibold text-ink truncate"><%= connection.name %></span>
+                  <% if connection.is_default %><span class="font-mono text-[10px] text-accent bg-accent-soft rounded-[4px] px-[7px] py-[2px]">DEFAULT</span><% end %>
+                </div>
+                <div class="font-mono text-[12px] text-mut mt-[3px] truncate"><%= connection.service_name %> · <%= connection.summary %></div>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 flex-none">
+              <% unless connection.is_default %>
+                <%= button_to "Make default", storage_connection_default_path(connection), method: :post, class: "btn-secondary", form_class: "inline" %>
+              <% end %>
+              <%= button_to storage_connection_path(connection), method: :delete, class: "btn-secondary btn-danger", form_class: "inline",
+                    "aria-label": "Remove connection", data: { turbo_confirm: "Remove storage connection \"#{connection.name}\"?" } do %>
+                <%= mi "delete", size: 16 %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="border border-dashed border-line rounded-[9px] px-[26px] py-9 flex flex-col items-center text-center bg-surface-2 mb-4">
+        <div class="w-[44px] h-[44px] border-[1.5px] border-line rounded-[11px] flex items-center justify-center text-faint bg-surface mb-[14px]"><%= mi "database", size: 22 %></div>
+        <h3 class="m-0 text-[15px] font-semibold text-ink">No storage connected</h3>
+        <p class="mt-[7px] mb-0 text-[13px] text-mut max-w-[340px] leading-[1.5]">Backups currently use the default Active Storage service. Add a connection to route them to a named bucket.</p>
+      </div>
+    <% end %>
+
+    <%= form_with url: storage_connections_path, method: :post, local: true, html: { class: "grid grid-cols-1 sm:grid-cols-4 gap-3 items-end" } do %>
+      <div class="flex flex-col gap-[7px]">
+        <label class="text-[12.5px] font-medium text-ink-2">Name</label>
+        <%= text_field_tag "storage_connection[name]", nil, placeholder: "Production", required: true, class: "text-[14px]" %>
+      </div>
+      <div class="flex flex-col gap-[7px]">
+        <label class="text-[12.5px] font-medium text-ink-2">Service</label>
+        <%= select_tag "storage_connection[service_name]", options_for_select(@available_services), class: "text-[14px]" %>
+      </div>
+      <div class="flex flex-col gap-[7px]">
+        <label class="text-[12.5px] font-medium text-ink-2">Bucket</label>
+        <%= text_field_tag "storage_connection[bucket]", nil, placeholder: "optional", class: "text-[14px]" %>
+      </div>
+      <%= submit_tag "Add connection", class: "btn" %>
+    <% end %>
+  </div>
+
+  <%# ---- Rate limiting ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "speed", size: 19, css: "text-ink-3" %>Rate limiting</div>
+    <div class="text-[13px] text-mut mt-[3px] mb-[18px]">Per-IP request limits for the saveMissing API and public delivery. Defaults apply to every project; a project can override them in its own settings.</div>
+
+    <%= form_with model: @setting, url: workspace_path, method: :patch, local: true do |form| %>
+      <% if @setting.errors.any? %>
+        <ul class="mb-4 text-[13px] text-danger-ink bg-danger-soft border border-danger-border rounded-[9px] px-4 py-3 list-disc list-inside">
+          <% @setting.errors.full_messages.each do |msg| %><li><%= msg %></li><% end %>
+        </ul>
+      <% end %>
+
+      <label class="flex items-center gap-[10px] mb-[18px] cursor-pointer">
+        <%= form.check_box :rate_limiting_enabled, class: "w-[16px] h-[16px]" %>
+        <span class="text-[13.5px] text-ink-2">Enable rate limiting</span>
+      </label>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :missing_rate_limit, "saveMissing — requests", class: "text-[12.5px] font-medium text-ink-2" %>
+          <%= form.number_field :missing_rate_limit, min: 1, class: "text-[14px]" %>
+        </div>
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :missing_rate_period, "saveMissing — window (seconds)", class: "text-[12.5px] font-medium text-ink-2" %>
+          <%= form.number_field :missing_rate_period, min: 1, class: "text-[14px]" %>
+        </div>
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :delivery_rate_limit, "Delivery — requests", class: "text-[12.5px] font-medium text-ink-2" %>
+          <%= form.number_field :delivery_rate_limit, min: 1, class: "text-[14px]" %>
+        </div>
+        <div class="flex flex-col gap-[7px]">
+          <%= form.label :delivery_rate_period, "Delivery — window (seconds)", class: "text-[12.5px] font-medium text-ink-2" %>
+          <%= form.number_field :delivery_rate_period, min: 1, class: "text-[14px]" %>
+        </div>
+      </div>
+
+      <div class="flex justify-end mt-[18px]">
+        <%= form.submit "Save changes", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module Back
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Enqueue jobs only after the surrounding DB transaction commits, so a job
+    # never runs before the records it depends on are visible.
+    config.active_job.enqueue_after_transaction_commit = true
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,82 @@
+# Rate limiting for the inbound write path (saveMissing) and public delivery.
+#
+# Limits are NOT hardcoded: they come from the global Setting row, optionally
+# overridden per-project, so self-hosters can tune them from the Workspace and
+# Project Settings panels without a redeploy. Per-(kind,slug) limits are cached
+# for 60s so throttling stays off the database hot path.
+Rails.application.config.middleware.use Rack::Attack
+
+class Rack::Attack
+  Rack::Attack.cache.store = Rails.cache
+
+  MISSING_PATH  = %r{\A/api/v1/projects/([^/]+)/missing/?\z}
+  DELIVERY_PATH = %r{\A/cdn/([^/]+)/}
+
+  # Returns { limit:, period: } for a request when throttling applies, else nil
+  # (unknown path, throttling disabled, or DB not yet available at boot).
+  def self.rule_for(req, kind, path_regex)
+    match = req.path.match(path_regex)
+    return unless match
+
+    setting = Setting.current
+    return unless setting.rate_limiting_enabled
+
+    limit = effective_limit(match[1], kind, setting)
+    return unless limit
+
+    period = kind == :missing ? setting.missing_rate_period : setting.delivery_rate_period
+    { limit: limit, period: period }
+  rescue ActiveRecord::ActiveRecordError
+    nil
+  end
+
+  def self.effective_limit(slug, kind, setting)
+    Rails.cache.fetch("rate_limit:#{kind}:#{slug}", expires_in: 60.seconds) do
+      project  = Project.find_by(slug: slug)
+      override = kind == :missing ? project&.missing_rate_limit : project&.delivery_rate_limit
+      override || (kind == :missing ? setting.missing_rate_limit : setting.delivery_rate_limit)
+    end
+  end
+
+  throttle("missing/ip",
+           limit:  ->(req) { req.env["rack_attack.rule"][:limit] },
+           period: ->(req) { req.env["rack_attack.rule"][:period] }) do |req|
+    if req.post? && (rule = rule_for(req, :missing, MISSING_PATH))
+      req.env["rack_attack.rule"] = rule
+      req.ip
+    end
+  end
+
+  throttle("delivery/ip",
+           limit:  ->(req) { req.env["rack_attack.rule"][:limit] },
+           period: ->(req) { req.env["rack_attack.rule"][:period] }) do |req|
+    if req.get? && (rule = rule_for(req, :delivery, DELIVERY_PATH))
+      req.env["rack_attack.rule"] = rule
+      req.ip
+    end
+  end
+
+  # 429 with Retry-After (seconds until the throttle window resets).
+  self.throttled_responder = lambda do |req|
+    match    = req.env["rack.attack.match_data"] || {}
+    period   = match[:period] || 60
+    epoch    = match[:epoch_time] || 0
+    reset_in = period - (epoch % period)
+    [ 429,
+      { "Content-Type" => "application/json", "Retry-After" => reset_in.to_s },
+      [ { error: "Rate limit exceeded. Retry later." }.to_json ] ]
+  end
+end
+
+# Log throttle events.
+ActiveSupport::Notifications.subscribe("rack.attack") do |_name, _start, _finish, _id, payload|
+  req = payload[:request]
+  next unless req.env["rack.attack.match_type"] == :throttle
+
+  Rails.logger.warn(
+    "[Rack::Attack] throttled name=#{req.env['rack.attack.matched']} ip=#{req.ip} path=#{req.path}"
+  )
+end
+
+# Throttling depends on a working cache + DB; keep it out of the test suite.
+Rack::Attack.enabled = false if Rails.env.test?

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  backup_translations:
+    class: BackupAllProjectsJob
+    schedule: every day at 3am

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,31 @@ Rails.application.routes.draw do
   get  "invitations/:token", to: "invitations#show",   as: :accept_invitation
   post "invitations/:token", to: "invitations#accept", as: :claim_invitation
 
+  # Global, admin-only workspace settings (rate-limit defaults).
+  resource :workspace, only: %i[ show update ], controller: "workspace"
+
+  resources :storage_connections, only: %i[ create destroy ] do
+    resource :default, only: :create, controller: "storage_connections/defaults"
+  end
+
+  # Workspace members (users) and the signed-in user's own account.
+  resources :members, only: %i[ index update destroy ]
+  resource :account, only: :show, controller: "account"
+  namespace :account do
+    resource :sessions, only: :destroy # revoke all sessions but the current one
+  end
+
   resources :projects, only: %i[ index new create show edit update destroy ] do
     resource :activity, only: :show, controller: "projects/activity"
     resource :settings, only: :show, controller: "projects/settings"
+    resources :api_tokens, only: %i[ create destroy ], controller: "projects/api_tokens"
+    resources :missing, only: %i[ index destroy ], controller: "projects/missing" do
+      resource :promotion, only: :create, controller: "projects/missing/promotions"
+    end
+    resources :backups, only: %i[ index create destroy ], controller: "projects/backups" do
+      resource :restoration, only: :create, controller: "projects/backups/restorations"
+    end
+    resource :backup_schedule, only: :update, controller: "projects/backup_schedules"
     resources :locales, only: %i[ create update destroy ]
     resources :namespaces, only: %i[ create update destroy show ], constraints: { id: %r{[^/]+} } do
       resource :publication, only: :create, module: :namespaces
@@ -28,6 +50,12 @@ Rails.application.routes.draw do
   # top-level app routes. namespace may contain dots, so the optional ".json"
   # suffix (i18next loadPath convention) is stripped in the controller rather
   # than parsed as a format.
+  namespace :api do
+    namespace :v1 do
+      post "projects/:project_slug/missing", to: "missing_translations#create"
+    end
+  end
+
   get "cdn/:project_slug/:locale/:namespace" => "delivery#show",
       as: :delivery,
       format: false,

--- a/db/migrate/20260628020000_create_api_tokens.rb
+++ b/db/migrate/20260628020000_create_api_tokens.rb
@@ -1,0 +1,17 @@
+class CreateApiTokens < ActiveRecord::Migration[8.1]
+  def change
+    create_table :api_tokens, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :project, type: :uuid, null: false, foreign_key: true
+      t.references :creator, type: :uuid, foreign_key: { to_table: :users, on_delete: :nullify }
+      t.string :name, null: false
+      t.string :token_digest, null: false
+      t.string :scope, null: false
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+
+      t.timestamps
+    end
+
+    add_index :api_tokens, :token_digest, unique: true
+  end
+end

--- a/db/migrate/20260628020001_create_settings.rb
+++ b/db/migrate/20260628020001_create_settings.rb
@@ -1,0 +1,13 @@
+class CreateSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :settings, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.boolean :rate_limiting_enabled, null: false, default: true
+      t.integer :missing_rate_limit,    null: false, default: 30
+      t.integer :missing_rate_period,   null: false, default: 60
+      t.integer :delivery_rate_limit,   null: false, default: 300
+      t.integer :delivery_rate_period,  null: false, default: 60
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260628020100_add_rate_limit_overrides_to_projects.rb
+++ b/db/migrate/20260628020100_add_rate_limit_overrides_to_projects.rb
@@ -1,0 +1,7 @@
+class AddRateLimitOverridesToProjects < ActiveRecord::Migration[8.1]
+  def change
+    # Nullable per-project overrides — NULL means "inherit the global Setting".
+    add_column :projects, :missing_rate_limit,  :integer
+    add_column :projects, :delivery_rate_limit, :integer
+  end
+end

--- a/db/migrate/20260628020200_add_delivery_path_template_to_projects.rb
+++ b/db/migrate/20260628020200_add_delivery_path_template_to_projects.rb
@@ -1,0 +1,8 @@
+class AddDeliveryPathTemplateToProjects < ActiveRecord::Migration[8.1]
+  def change
+    # Deterministic Active Storage key template for materialized artifacts.
+    # Default is project-scoped so keys stay globally unique across projects.
+    add_column :projects, :delivery_path_template, :string,
+               null: false, default: "{project_slug}/{namespace}/{locale}.json"
+  end
+end

--- a/db/migrate/20260628020300_create_project_backups.rb
+++ b/db/migrate/20260628020300_create_project_backups.rb
@@ -1,0 +1,14 @@
+class CreateProjectBackups < ActiveRecord::Migration[8.1]
+  def change
+    create_table :project_backups, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :project, type: :uuid, null: false, foreign_key: true
+      t.string :checksum, null: false
+      t.integer :translations_count, null: false, default: 0
+      t.bigint :byte_size, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :project_backups, [ :project_id, :created_at ]
+  end
+end

--- a/db/migrate/20260628020400_add_backup_settings_to_projects.rb
+++ b/db/migrate/20260628020400_add_backup_settings_to_projects.rb
@@ -1,0 +1,11 @@
+class AddBackupSettingsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :backups_enabled,       :boolean, null: false, default: true
+    add_column :projects, :backup_frequency,      :string,  null: false, default: "daily" # daily|weekly|monthly
+    add_column :projects, :backup_retention,      :integer, null: false, default: 30
+    add_column :projects, :backup_include_drafts, :boolean, null: false, default: false
+
+    # Provenance of each snapshot, for the AUTO/MANUAL badge.
+    add_column :project_backups, :source, :string, null: false, default: "manual"
+  end
+end

--- a/db/migrate/20260628020500_create_missing_key_reports.rb
+++ b/db/migrate/20260628020500_create_missing_key_reports.rb
@@ -1,0 +1,18 @@
+class CreateMissingKeyReports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :missing_key_reports, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.references :project, type: :uuid, null: false, foreign_key: true
+      t.string :namespace, null: false
+      t.string :key, null: false
+      t.integer :hits, null: false, default: 0
+      t.jsonb :locales, null: false, default: []
+      t.datetime :first_reported_at
+      t.datetime :last_reported_at
+
+      t.timestamps
+    end
+
+    add_index :missing_key_reports, [ :project_id, :namespace, :key ], unique: true
+    add_index :missing_key_reports, [ :project_id, :last_reported_at ]
+  end
+end

--- a/db/migrate/20260628020600_create_storage_connections.rb
+++ b/db/migrate/20260628020600_create_storage_connections.rb
@@ -1,0 +1,13 @@
+class CreateStorageConnections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :storage_connections, id: :uuid, default: -> { "uuidv7()" } do |t|
+      t.string :name, null: false
+      t.string :service_name, null: false # an Active Storage service from config/storage.yml
+      t.string :bucket
+      t.string :region
+      t.boolean :is_default, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_020600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "api_tokens", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "creator_id"
+    t.datetime "last_used_at"
+    t.string "name", null: false
+    t.uuid "project_id", null: false
+    t.datetime "revoked_at"
+    t.string "scope", null: false
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_api_tokens_on_creator_id"
+    t.index ["project_id"], name: "index_api_tokens_on_project_id"
+    t.index ["token_digest"], name: "index_api_tokens_on_token_digest", unique: true
   end
 
   create_table "events", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -79,6 +94,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
     t.index ["project_id"], name: "index_locales_on_project_id"
   end
 
+  create_table "missing_key_reports", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "first_reported_at"
+    t.integer "hits", default: 0, null: false
+    t.string "key", null: false
+    t.datetime "last_reported_at"
+    t.jsonb "locales", default: [], null: false
+    t.string "namespace", null: false
+    t.uuid "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "last_reported_at"], name: "index_missing_key_reports_on_project_id_and_last_reported_at"
+    t.index ["project_id", "namespace", "key"], name: "index_missing_key_reports_on_project_id_and_namespace_and_key", unique: true
+    t.index ["project_id"], name: "index_missing_key_reports_on_project_id"
+  end
+
   create_table "namespaces", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
@@ -88,9 +118,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
     t.index ["project_id", "name"], name: "index_namespaces_on_project_id_and_name", unique: true
   end
 
-  create_table "projects", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+  create_table "project_backups", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.bigint "byte_size", default: 0, null: false
+    t.string "checksum", null: false
     t.datetime "created_at", null: false
+    t.uuid "project_id", null: false
+    t.string "source", default: "manual", null: false
+    t.integer "translations_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "created_at"], name: "index_project_backups_on_project_id_and_created_at"
+    t.index ["project_id"], name: "index_project_backups_on_project_id"
+  end
+
+  create_table "projects", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.string "backup_frequency", default: "daily", null: false
+    t.boolean "backup_include_drafts", default: false, null: false
+    t.integer "backup_retention", default: 30, null: false
+    t.boolean "backups_enabled", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "delivery_path_template", default: "{project_slug}/{namespace}/{locale}.json", null: false
+    t.integer "delivery_rate_limit"
     t.integer "locales_count", default: 0, null: false
+    t.integer "missing_rate_limit"
     t.string "name", null: false
     t.integer "namespaces_count", default: 0, null: false
     t.string "slug", null: false
@@ -110,6 +159,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "settings", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "delivery_rate_limit", default: 300, null: false
+    t.integer "delivery_rate_period", default: 60, null: false
+    t.integer "missing_rate_limit", default: 30, null: false
+    t.integer "missing_rate_period", default: 60, null: false
+    t.boolean "rate_limiting_enabled", default: true, null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "sign_in_tokens", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
@@ -118,6 +177,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
     t.uuid "user_id", null: false
     t.index ["token"], name: "index_sign_in_tokens_on_token", unique: true
     t.index ["user_id"], name: "index_sign_in_tokens_on_user_id"
+  end
+
+  create_table "storage_connections", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.string "bucket"
+    t.datetime "created_at", null: false
+    t.boolean "is_default", default: false, null: false
+    t.string "name", null: false
+    t.string "region"
+    t.string "service_name", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "translation_approvals", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
@@ -208,10 +277,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_015800) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "api_tokens", "projects"
+  add_foreign_key "api_tokens", "users", column: "creator_id", on_delete: :nullify
   add_foreign_key "events", "users", column: "creator_id"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "locales", "projects"
+  add_foreign_key "missing_key_reports", "projects"
   add_foreign_key "namespaces", "projects"
+  add_foreign_key "project_backups", "projects"
   add_foreign_key "sessions", "users"
   add_foreign_key "sign_in_tokens", "users"
   add_foreign_key "translation_approvals", "translations"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,50 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Minimal data for local development. Idempotent (find_or_create_by!) so it is
+# safe to run repeatedly. Single-tenant: one admin, one project.
+
+admin = User.find_or_create_by!(email: "admin@example.com") { |u| u.role = "admin" }
+
+project = Project.find_or_create_by!(slug: "main-app") { |p| p.name = "Main App" }
+
+locales = %w[ en pt-BR es ].index_with { |code| project.locales.find_or_create_by!(code:) }
+common  = project.namespaces.find_or_create_by!(name: "common")
+auth    = project.namespaces.find_or_create_by!(name: "auth")
+
+catalog = {
+  common => {
+    "common.welcome" => { "en" => "Welcome",   "pt-BR" => "Bem-vindo",   "es" => "Bienvenido" },
+    "common.goodbye" => { "en" => "Goodbye",    "pt-BR" => "Tchau",       "es" => "Adiós" },
+    "common.yes"     => { "en" => "Yes",        "pt-BR" => "Sim",         "es" => "Sí" },
+    "common.no"      => { "en" => "No",         "pt-BR" => "Não",         "es" => "No" },
+    "common.loading" => { "en" => "Loading…",   "pt-BR" => "Carregando…", "es" => "Cargando…" },
+    "common.save"    => { "en" => "Save",       "pt-BR" => "Salvar",      "es" => "Guardar" }
+  },
+  auth => {
+    "auth.signin"   => { "en" => "Sign in",  "pt-BR" => "Entrar", "es" => "Iniciar sesión" },
+    "auth.signout"  => { "en" => "Sign out", "pt-BR" => "Sair",   "es" => "Cerrar sesión" },
+    "auth.email"    => { "en" => "Email",    "pt-BR" => "E-mail", "es" => "Correo" },
+    "auth.password" => { "en" => "Password", "pt-BR" => "Senha",  "es" => "Contraseña" }
+  }
+}
+
+# Fill every (key, locale); publish every other translation so the dev DB has a
+# mix of published and draft state (state = presence of a Publication record).
+index = 0
+catalog.each do |namespace, keys|
+  keys.each do |key_path, values|
+    translation_key = namespace.translation_keys.find_or_create_by!(project:, key: key_path)
+    values.each do |code, value|
+      translation = translation_key.set_translation(locale: locales[code], value:, author: admin)
+      translation.publish(by: admin) if index.even? && !translation.published?
+      index += 1
+    end
+  end
+end
+
+# A dev API token for exercising the saveMissing endpoint locally (shown once).
+unless project.api_tokens.active.exists?
+  _token, raw = ApiToken.generate(project:, name: "Local dev", scope: "save_missing", creator: admin)
+  puts "\n  saveMissing API token for #{project.slug}: #{raw}\n\n"
+end
+
+puts "Seeded #{project.name}: #{project.locales_count} locales, " \
+     "#{project.namespaces_count} namespaces, #{project.translation_keys_count} keys."

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,67 @@
+# Cloud backups (translations)
+
+Language Bridge periodically snapshots every project's translations to the
+configured **Active Storage** service — your own S3/GCS bucket when configured,
+local Disk otherwise. A backup is a single, self-contained JSON document: every
+namespace, key, locale, value and published state. It is restorable on its own
+(no database dump needed).
+
+## What a backup contains
+
+```json
+{
+  "version": 1,
+  "created_at": "2026-06-28T03:00:00Z",
+  "project": { "slug": "main-app", "name": "Main App" },
+  "locales": ["en", "pt-BR", "es"],
+  "namespaces": {
+    "common": {
+      "common.welcome": {
+        "en":    { "value": "Welcome",   "published": true },
+        "pt-BR": { "value": "Bem-vindo", "published": false }
+      }
+    }
+  }
+}
+```
+
+Stored at a readable key in the service:
+`backups/{project_slug}/{YYYYMMDD-HHMMSS}-{id}.json`.
+
+## Scheduling
+
+A recurring Solid Queue job snapshots **all projects daily** — see
+`config/recurring.yml`:
+
+```yaml
+backup_translations:
+  class: BackupAllProjectsJob
+  schedule: every day at 3am
+```
+
+`BackupAllProjectsJob` fans out one `BackupProjectJob` per project. Each writes a
+snapshot blob and prunes older backups beyond the retention limit
+(`BACKUP_KEEP`, default 30). Point Active Storage at a cloud bucket to get
+off-box, durable backups automatically.
+
+> Recurring jobs run wherever the Solid Queue supervisor runs (e.g. Puma with
+> `SOLID_QUEUE_IN_PUMA=1`, or a dedicated worker).
+
+## Manual backup, download, restore
+
+Project Settings → **Cloud backups**:
+
+- **Back up now** — creates a snapshot immediately.
+- **Download** — the raw JSON blob.
+- **Restore** — re-imports a snapshot: creates any missing locales/namespaces/keys
+  and upserts values (re-publishing where the snapshot was published). Restore is
+  an **upsert** — it never deletes keys or translations that aren't in the
+  snapshot.
+
+## Notes
+
+- Backups contain translation content (and could contain sensitive strings). The
+  bucket inherits whatever access controls you set on the Active Storage service;
+  treat it accordingly.
+- Snapshots are deterministic — re-running a backup with no changes produces the
+  same content (matching `checksum`).

--- a/docs/delivery-paths.md
+++ b/docs/delivery-paths.md
@@ -1,0 +1,48 @@
+# Delivery path templates (own bucket / CDN)
+
+Materialized i18n artifacts are stored in the configured **Active Storage**
+service under a **deterministic, human-readable object key** so you can point a
+CDN origin straight at them in your own bucket.
+
+## The template
+
+Each project has a `delivery_path_template` (Project Settings → Public delivery).
+It renders the storage key for every `(namespace, locale)` artifact. Tokens:
+
+| Token | Example |
+|-------|---------|
+| `{project_slug}` | `main-app` |
+| `{namespace}`    | `common` |
+| `{locale}`       | `pt-BR` |
+
+Default: `{project_slug}/{namespace}/{locale}.json` →
+`main-app/common/pt-BR.json`.
+
+Rules (validated): no leading `/`, only the tokens above, **must include
+`{namespace}` and `{locale}`** (so each pair is unique), path-safe characters
+only.
+
+> **Multi-project instances:** keep `{project_slug}` in the template. Object keys
+> share one bucket namespace; dropping `{project_slug}` lets two projects with the
+> same namespace+locale collide on one key.
+
+## Pointing at your own bucket
+
+1. Configure an S3/GCS service in `config/storage.yml` and select it:
+   `config.active_storage.service = :amazon` (per environment).
+2. Set the template to the layout your CDN expects.
+3. Point the CDN origin at the bucket. Objects land at the templated key
+   (S3/GCS use the key verbatim). The Rails route `GET /cdn/:project/:locale/:namespace`
+   keeps working regardless — the key change is storage-side only.
+
+> The local **Disk** service sublards objects by a key prefix, so the on-disk path
+> won't match the template literally. Predictable paths apply to S3/GCS.
+
+## Changing the template
+
+Saving a new template **re-materializes** all of the project's artifacts at the
+new keys and **purges the blobs at the old keys**. On large instances this runs
+on the request; moving it to a background job is tracked in #43.
+
+A normal content edit keeps the same key and overwrites the object **in place**
+(no key churn), so CDN URLs stay stable across translation edits.

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class AccountControllerTest < ActionDispatch::IntegrationTest
+  test "shows the signed-in user's account" do
+    sign_in_as(users(:translator))
+    get account_path
+    assert_response :success
+    assert_select "h1", "Account"
+    assert_select "body", /#{users(:translator).email}/
+  end
+
+  test "revokes all other sessions but keeps the current one" do
+    user = users(:translator)
+    other = user.sessions.create!(user_agent: "Old", ip_address: "1.2.3.4")
+    sign_in_as(user)
+
+    assert_difference -> { user.sessions.count }, -1 do
+      delete account_sessions_path
+    end
+    assert_redirected_to account_path
+    assert_not Session.exists?(other.id), "other session revoked"
+    assert_equal 1, user.sessions.count, "current session kept"
+  end
+end

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class MembersControllerTest < ActionDispatch::IntegrationTest
+  test "admin lists members" do
+    sign_in_as(users(:admin))
+    get members_path
+    assert_response :success
+    assert_select "h2", "Members"
+  end
+
+  test "admin changes another member's role" do
+    sign_in_as(users(:admin))
+    patch member_path(users(:translator)), params: { user: { role: "viewer" } }
+    assert_redirected_to members_path
+    assert_equal "viewer", users(:translator).reload.role
+  end
+
+  test "admin cannot change own role" do
+    sign_in_as(users(:admin))
+    patch member_path(users(:admin)), params: { user: { role: "viewer" } }
+    assert_equal "admin", users(:admin).reload.role
+  end
+
+  test "admin removes another member" do
+    sign_in_as(users(:admin))
+    assert_difference -> { User.count }, -1 do
+      delete member_path(users(:viewer))
+    end
+    assert_redirected_to members_path
+  end
+
+  test "admin cannot remove self" do
+    sign_in_as(users(:admin))
+    assert_no_difference -> { User.count } do
+      delete member_path(users(:admin))
+    end
+  end
+
+  test "non-admin is blocked" do
+    sign_in_as(users(:translator))
+    get members_path
+    assert_redirected_to root_path
+  end
+end

--- a/test/controllers/projects/api_tokens_controller_test.rb
+++ b/test/controllers/projects/api_tokens_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class Projects::ApiTokensControllerTest < ActionDispatch::IntegrationTest
+  setup { @project = projects(:main_app) }
+
+  test "admin creates a token and sees the raw value once" do
+    sign_in_as(users(:admin))
+    assert_difference -> { @project.api_tokens.count }, 1 do
+      post project_api_tokens_path(@project), params: { api_token: { name: "Web client", scope: "save_missing" } }
+    end
+    assert_redirected_to project_settings_path(@project)
+    assert flash[:token_created].present?, "raw token should be flashed once"
+    assert_equal "save_missing", @project.api_tokens.order(:created_at).last.scope
+  end
+
+  test "admin revokes a token" do
+    sign_in_as(users(:admin))
+    token = api_tokens(:save_missing)
+    delete project_api_token_path(@project, token)
+    assert_redirected_to project_settings_path(@project)
+    assert_not_nil token.reload.revoked_at
+  end
+
+  test "non-admin cannot manage tokens" do
+    sign_in_as(users(:translator))
+    post project_api_tokens_path(@project), params: { api_token: { name: "x", scope: "save_missing" } }
+    assert_response :forbidden
+  end
+end

--- a/test/controllers/projects/backups_controller_test.rb
+++ b/test/controllers/projects/backups_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Projects::BackupsControllerTest < ActionDispatch::IntegrationTest
+  setup { @project = projects(:main_app) }
+
+  test "admin sees the backups tab" do
+    sign_in_as(users(:admin))
+    get project_backups_path(@project)
+    assert_response :success
+    assert_select "h2", "Backups"
+  end
+
+  test "admin backs up now" do
+    sign_in_as(users(:admin))
+    assert_difference -> { @project.backups.count }, 1 do
+      post project_backups_path(@project)
+    end
+    assert_redirected_to project_backups_path(@project)
+    assert_equal "manual", @project.backups.recent.first.source
+  end
+
+  test "admin saves the backup schedule" do
+    sign_in_as(users(:admin))
+    patch project_backup_schedule_path(@project), params: { project: {
+      backups_enabled: "1", backup_frequency: "weekly", backup_retention: 10, backup_include_drafts: "1"
+    } }
+    assert_redirected_to project_backups_path(@project)
+    @project.reload
+    assert_equal "weekly", @project.backup_frequency
+    assert_equal 10, @project.backup_retention
+    assert @project.backup_include_drafts
+  end
+
+  test "admin restores from a backup" do
+    sign_in_as(users(:admin))
+    BackupProjectJob.perform_now(@project)
+    backup = @project.backups.recent.first
+
+    post project_backup_restoration_path(@project, backup)
+    assert_redirected_to project_backups_path(@project)
+  end
+
+  test "non-admin cannot back up" do
+    sign_in_as(users(:translator))
+    post project_backups_path(@project)
+    assert_response :forbidden
+  end
+
+  test "restore rejects a tampered snapshot instead of crashing" do
+    sign_in_as(users(:admin))
+    BackupProjectJob.perform_now(@project)
+    backup = @project.backups.recent.first
+    backup.update_column(:checksum, "deadbeef") # corrupt the recorded checksum
+
+    post project_backup_restoration_path(@project, backup)
+    assert_redirected_to project_backups_path(@project)
+    assert_match(/integrity check failed/i, flash[:alert])
+  end
+end

--- a/test/controllers/projects/missing_controller_test.rb
+++ b/test/controllers/projects/missing_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Projects::MissingControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @project = projects(:main_app)
+    @report = @project.missing_key_reports.create!(
+      namespace: "emails", key: "welcome.subject", hits: 3, locales: %w[ en pt-BR ], last_reported_at: Time.current
+    )
+  end
+
+  test "lists reported missing keys" do
+    sign_in_as(users(:translator))
+    get project_missing_index_path(@project)
+    assert_response :success
+    assert_select "h2", "Missing translations"
+  end
+
+  test "promote creates a real key with empty translations and removes the report" do
+    sign_in_as(users(:translator))
+    assert_difference -> { @project.translation_keys.count }, 1 do
+      assert_difference -> { @project.missing_key_reports.count }, -1 do
+        post project_missing_promotion_path(@project, @report)
+      end
+    end
+    assert_redirected_to project_missing_index_path(@project)
+
+    namespace = @project.namespaces.find_by(name: "emails")
+    key = @project.translation_keys.find_by(namespace: namespace, key: "welcome.subject")
+    assert_not_nil key
+    assert_equal %w[ en pt-BR ].sort, key.translations.map { |t| t.locale.code }.sort
+    assert key.translations.all? { |t| t.value.nil? }, "promoted translations start empty"
+  end
+
+  test "ignore removes the report" do
+    sign_in_as(users(:translator))
+    assert_difference -> { @project.missing_key_reports.count }, -1 do
+      delete project_missing_path(@project, @report)
+    end
+    assert_redirected_to project_missing_index_path(@project)
+  end
+
+  test "viewers cannot promote or ignore" do
+    sign_in_as(users(:viewer))
+    post project_missing_promotion_path(@project, @report)
+    assert_response :forbidden
+    delete project_missing_path(@project, @report)
+    assert_response :forbidden
+  end
+end

--- a/test/controllers/projects_rate_limit_override_test.rb
+++ b/test/controllers/projects_rate_limit_override_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ProjectsRateLimitOverrideTest < ActionDispatch::IntegrationTest
+  setup { @project = projects(:main_app) }
+
+  test "admin sets a per-project rate-limit override" do
+    sign_in_as(users(:admin))
+    patch project_path(@project), params: { project: { missing_rate_limit: 50, delivery_rate_limit: 400 } }
+    assert_redirected_to project_path(@project)
+    @project.reload
+    assert_equal 50, @project.missing_rate_limit
+    assert_equal 50, @project.effective_missing_limit
+    assert_equal 400, @project.effective_delivery_limit
+  end
+
+  test "blank override falls back to the global default" do
+    @project.update!(missing_rate_limit: 50)
+    assert_equal 50, @project.effective_missing_limit
+    @project.update!(missing_rate_limit: nil)
+    assert_equal Setting.current.missing_rate_limit, @project.effective_missing_limit
+  end
+end

--- a/test/controllers/storage_connections_controller_test.rb
+++ b/test/controllers/storage_connections_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class StorageConnectionsControllerTest < ActionDispatch::IntegrationTest
+  test "admin adds a connection (first one becomes default)" do
+    sign_in_as(users(:admin))
+    assert_difference -> { StorageConnection.count }, 1 do
+      post storage_connections_path, params: { storage_connection: { name: "Prod", service_name: "test", bucket: "my-bucket" } }
+    end
+    assert_redirected_to workspace_path
+    assert StorageConnection.last.is_default
+  end
+
+  test "admin makes a connection default and removes one" do
+    sign_in_as(users(:admin))
+    a = StorageConnection.create!(name: "A", service_name: "test", is_default: true)
+    b = StorageConnection.create!(name: "B", service_name: "local")
+
+    post storage_connection_default_path(b)
+    assert b.reload.is_default
+    assert_not a.reload.is_default
+
+    assert_difference -> { StorageConnection.count }, -1 do
+      delete storage_connection_path(a)
+    end
+  end
+
+  test "non-admin is blocked" do
+    sign_in_as(users(:translator))
+    post storage_connections_path, params: { storage_connection: { name: "X", service_name: "test" } }
+    assert_redirected_to root_path
+  end
+end

--- a/test/controllers/workspace_controller_test.rb
+++ b/test/controllers/workspace_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class WorkspaceControllerTest < ActionDispatch::IntegrationTest
+  test "admin sees the workspace settings page" do
+    sign_in_as(users(:admin))
+    get workspace_path
+    assert_response :success
+    assert_select "h2", "Workspace settings"
+  end
+
+  test "admin updates global rate-limit settings" do
+    sign_in_as(users(:admin))
+    patch workspace_path, params: { setting: {
+      rate_limiting_enabled: "1", missing_rate_limit: 45, missing_rate_period: 30,
+      delivery_rate_limit: 500, delivery_rate_period: 60
+    } }
+    assert_redirected_to workspace_path
+    assert_equal 45, Setting.current.missing_rate_limit
+    assert_equal 500, Setting.current.delivery_rate_limit
+  end
+
+  test "non-admin is redirected away" do
+    sign_in_as(users(:translator))
+    get workspace_path
+    assert_redirected_to root_path
+  end
+end

--- a/test/fixtures/api_tokens.yml
+++ b/test/fixtures/api_tokens.yml
@@ -1,0 +1,16 @@
+# token_digest is the SHA-256 of the raw token used in tests. The raw values are:
+#   save_missing -> "test-save-missing-token"
+#   read_only    -> "test-read-only-token"
+save_missing:
+  project: main_app
+  creator: admin
+  name: CI saveMissing
+  scope: save_missing
+  token_digest: <%= Digest::SHA256.hexdigest("test-save-missing-token") %>
+
+read_only:
+  project: main_app
+  creator: admin
+  name: CI read only
+  scope: read_only
+  token_digest: <%= Digest::SHA256.hexdigest("test-read-only-token") %>

--- a/test/integration/api/v1/missing_translations_test.rb
+++ b/test/integration/api/v1/missing_translations_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Api::V1::MissingTranslationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @project = projects(:main_app)
+    @url = "/api/v1/projects/#{@project.slug}/missing"
+    @auth = { "Authorization" => "Bearer test-save-missing-token" }
+  end
+
+  def post_missing(headers: @auth, **body)
+    post @url, params: body, headers: headers, as: :json
+  end
+
+  test "records a report for an unknown key without creating real keys" do
+    assert_difference -> { MissingKeyReport.count }, 1 do
+      assert_no_difference [ "TranslationKey.count", "Translation.count" ] do
+        post_missing(locale: "en", namespace: "common", keys: { "brand.new" => "Fresh" })
+      end
+    end
+    assert_response :success
+    assert_equal({ "status" => "ok", "reported" => 1 }, response.parsed_body)
+
+    report = @project.missing_key_reports.find_by(namespace: "common", key: "brand.new")
+    assert_equal 1, report.hits
+    assert_equal [ "en" ], report.locales
+  end
+
+  test "replaying the same payload bumps hits, not rows" do
+    post_missing(locale: "en", namespace: "common", keys: { "brand.new" => "Fresh" })
+    assert_no_difference -> { MissingKeyReport.count } do
+      post_missing(locale: "en", namespace: "common", keys: { "brand.new" => "Fresh" })
+    end
+    assert_equal 2, @project.missing_key_reports.find_by(key: "brand.new").hits
+  end
+
+  test "accumulates the locales that report a key" do
+    post_missing(locale: "en", namespace: "common", keys: { "brand.new" => "x" })
+    post_missing(locale: "pt-BR", namespace: "common", keys: { "brand.new" => "x" })
+    assert_equal %w[ en pt-BR ], @project.missing_key_reports.find_by(key: "brand.new").locales
+  end
+
+  test "returns the count of reported keys" do
+    post_missing(locale: "en", namespace: "common", keys: { "a.one" => "1", "a.two" => "2" })
+    assert_response :success
+    assert_equal 2, response.parsed_body["reported"]
+  end
+
+  test "422 when keys are absent or empty" do
+    post_missing(locale: "en", namespace: "common")
+    assert_response :unprocessable_entity
+    post_missing(locale: "en", namespace: "common", keys: {})
+    assert_response :unprocessable_entity
+  end
+
+  test "422 when locale or namespace is missing" do
+    post_missing(namespace: "common", keys: { "a.one" => "1" })
+    assert_response :unprocessable_entity
+    post_missing(locale: "en", keys: { "a.one" => "1" })
+    assert_response :unprocessable_entity
+  end
+
+  test "404 when the project slug is unknown" do
+    post "/api/v1/projects/does-not-exist/missing",
+         params: { locale: "en", namespace: "common", keys: { "a.one" => "1" } },
+         headers: @auth, as: :json
+    assert_response :not_found
+  end
+
+  test "401 when the bearer token is missing or invalid" do
+    post_missing(headers: {}, locale: "en", namespace: "common", keys: { "a.one" => "1" })
+    assert_response :unauthorized
+    post_missing(headers: { "Authorization" => "Bearer wrong-token" }, locale: "en", namespace: "common", keys: { "a.one" => "1" })
+    assert_response :unauthorized
+  end
+
+  test "403 when the token lacks the save_missing scope" do
+    post_missing(headers: { "Authorization" => "Bearer test-read-only-token" }, locale: "en", namespace: "common", keys: { "a.one" => "1" })
+    assert_response :forbidden
+  end
+
+  test "422 when the payload exceeds the per-request key cap" do
+    keys = (1..501).to_h { |i| [ "k.#{i}", "v" ] }
+    assert_no_difference -> { MissingKeyReport.count } do
+      post_missing(locale: "en", namespace: "common", keys: keys)
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "422 when a namespace is absurdly long" do
+    post_missing(locale: "en", namespace: "n" * 300, keys: { "a.b" => "x" })
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/jobs/backup_all_projects_job_test.rb
+++ b/test/jobs/backup_all_projects_job_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class BackupAllProjectsJobTest < ActiveJob::TestCase
+  test "enqueues an auto backup only for enabled, due projects" do
+    due = projects(:main_app)
+    disabled = projects(:marketing_site)
+    disabled.update!(backups_enabled: false)
+
+    assert_enqueued_with(job: BackupProjectJob, args: [ due, { source: "auto" } ]) do
+      BackupAllProjectsJob.perform_now
+    end
+
+    # A project backed up moments ago (within its interval) is not due again.
+    BackupProjectJob.perform_now(due, source: "auto")
+    assert_no_enqueued_jobs only: BackupProjectJob do
+      BackupAllProjectsJob.perform_now
+    end
+  end
+end

--- a/test/jobs/backup_project_job_test.rb
+++ b/test/jobs/backup_project_job_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class BackupProjectJobTest < ActiveJob::TestCase
+  test "creates a backup with an attached snapshot at a readable key" do
+    project = projects(:main_app)
+
+    assert_difference -> { project.backups.count }, 1 do
+      BackupProjectJob.perform_now(project)
+    end
+
+    backup = project.backups.recent.first
+    assert backup.file.attached?
+    assert_equal "application/json", backup.file.content_type
+    assert backup.byte_size.positive?
+    assert_equal project.translations.count, backup.translations_count
+    assert_match %r{\Abackups/main-app/\d{8}-\d{6}-}, backup.file.key
+  end
+
+  test "routes the snapshot to the default storage connection's service" do
+    project = projects(:main_app)
+    StorageConnection.create!(name: "Local bucket", service_name: "local", is_default: true)
+
+    BackupProjectJob.perform_now(project)
+
+    assert_equal "local", project.backups.recent.first.file.blob.service_name
+  end
+
+  test "prunes backups beyond the per-project retention limit" do
+    project = projects(:main_app)
+    project.update!(backup_retention: 1)
+
+    BackupProjectJob.perform_now(project)
+    BackupProjectJob.perform_now(project)
+
+    assert_equal 1, project.backups.count
+  end
+end

--- a/test/models/project_delivery_template_test.rb
+++ b/test/models/project_delivery_template_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class ProjectDeliveryTemplateTest < ActiveSupport::TestCase
+  setup do
+    @project = projects(:main_app)
+    @namespace = namespaces(:main_app_common)   # name: common
+    @locale = locales(:main_app_pt_br)          # code: pt-BR
+  end
+
+  test "default template is project-scoped" do
+    assert_equal "{project_slug}/{namespace}/{locale}.json", Project.new(name: "X").delivery_path_template
+  end
+
+  test "delivery_key_for renders all tokens" do
+    @project.update!(delivery_path_template: "{project_slug}/{namespace}/{locale}.json")
+    assert_equal "main-app/common/pt-BR.json", @project.delivery_key_for(@namespace, @locale)
+  end
+
+  test "delivery_key_for honors a custom template" do
+    @project.update!(delivery_path_template: "i18n/{locale}/{namespace}.json")
+    assert_equal "i18n/pt-BR/common.json", @project.delivery_key_for(@namespace, @locale)
+  end
+
+  test "rejects a leading slash" do
+    @project.delivery_path_template = "/{namespace}/{locale}.json"
+    assert_not @project.valid?
+    assert_match(/must not start with/, @project.errors[:delivery_path_template].join)
+  end
+
+  test "rejects an unknown token" do
+    @project.delivery_path_template = "{bucket}/{namespace}/{locale}.json"
+    assert_not @project.valid?
+    assert_match(/unknown token \{bucket\}/, @project.errors[:delivery_path_template].join)
+  end
+
+  test "requires {namespace} and {locale}" do
+    @project.delivery_path_template = "{project_slug}/{locale}.json"
+    assert_not @project.valid?
+    assert_match(/must include \{namespace\}/, @project.errors[:delivery_path_template].join)
+
+    @project.delivery_path_template = "{project_slug}/{namespace}.json"
+    assert_not @project.valid?
+    assert_match(/must include \{locale\}/, @project.errors[:delivery_path_template].join)
+  end
+
+  test "rejects invalid literal characters" do
+    @project.delivery_path_template = "{namespace}/{locale} space.json"
+    assert_not @project.valid?
+    assert_match(/invalid characters/, @project.errors[:delivery_path_template].join)
+  end
+end

--- a/test/models/storage_connection_test.rb
+++ b/test/models/storage_connection_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class StorageConnectionTest < ActiveSupport::TestCase
+  test "validates the service against configured Active Storage services" do
+    assert StorageConnection.new(name: "Prod", service_name: "test").valid?
+    invalid = StorageConnection.new(name: "Bad", service_name: "nope")
+    assert_not invalid.valid?
+    assert_match(/configured storage service/, invalid.errors[:service_name].join)
+  end
+
+  test "marking a connection default unsets the others" do
+    a = StorageConnection.create!(name: "A", service_name: "test", is_default: true)
+    b = StorageConnection.create!(name: "B", service_name: "local", is_default: true)
+
+    assert_not a.reload.is_default
+    assert b.reload.is_default
+    assert_equal b, StorageConnection.default
+  end
+end

--- a/test/models/translation/artifact_delivery_key_test.rb
+++ b/test/models/translation/artifact_delivery_key_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Translation::ArtifactDeliveryKeyTest < ActiveSupport::TestCase
+  setup do
+    @project = projects(:main_app)
+    @namespace = namespaces(:main_app_common)   # common
+    @locale = locales(:main_app_en)             # en
+    @translation = translations(:greeting_en)   # key "greeting", value "Hello"
+    @translation.publish                        # gives the bundle published content
+  end
+
+  def rebuild
+    Translation::Artifact.rebuild(@namespace.id, @locale.id)
+  end
+
+  test "rebuild stores the blob at the deterministic template key" do
+    artifact = rebuild
+    assert artifact.file.attached?
+    assert_equal "main-app/common/en.json", artifact.file.key
+  end
+
+  test "a content edit reuses the same blob and key in place" do
+    artifact = rebuild
+    key = artifact.file.key
+    blob_id = artifact.file.blob.id
+    old_checksum = artifact.checksum
+
+    @translation.update!(value: "Hi there")
+    @translation.publish
+    artifact = rebuild
+
+    assert_equal key, artifact.file.key, "key must stay stable across edits"
+    assert_equal blob_id, artifact.file.blob.id, "same blob reused (in-place upload, no churn)"
+    assert_not_equal old_checksum, artifact.reload.checksum
+    assert_match "Hi there", artifact.file.download
+  end
+
+  test "changing the template re-keys and purges the old blob" do
+    artifact = rebuild
+    old_blob = artifact.file.blob
+
+    @project.update!(delivery_path_template: "i18n/{locale}/{namespace}.json")
+    artifact = rebuild
+
+    assert_equal "i18n/en/common.json", artifact.file.key
+    assert_not ActiveStorage::Blob.exists?(old_blob.id), "old blob must be purged"
+  end
+end

--- a/test/models/translation_snapshot_test.rb
+++ b/test/models/translation_snapshot_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class TranslationSnapshotTest < ActiveSupport::TestCase
+  test "build serializes namespaces, keys, locales, values and published state" do
+    source = projects(:main_app)
+    translations(:greeting_en).publish
+
+    data = JSON.parse(TranslationSnapshot.build(source).to_json)
+
+    assert_equal 1, data["version"]
+    assert_includes data["locales"], "en"
+    entry = data.dig("namespaces", "common", "greeting", "en")
+    assert_equal "Hello", entry["value"]
+    assert_equal true, entry["published"]
+  end
+
+  test "restore reproduces the translation set in a fresh project" do
+    source = projects(:main_app)
+    translations(:greeting_en).publish
+    data = JSON.parse(TranslationSnapshot.build(source).to_json)
+
+    target = Project.create!(name: "Restore Target")
+    count = TranslationSnapshot.restore(target, data)
+
+    assert count.positive?
+    namespace = target.namespaces.find_by(name: "common")
+    key = target.translation_keys.find_by(namespace: namespace, key: "greeting")
+    translation = key.translations.find_by(locale: target.locales.find_by(code: "en"))
+    assert_equal "Hello", translation.value
+    assert translation.published?, "published state should be restored"
+  end
+end

--- a/test/system/projects_search_test.rb
+++ b/test/system/projects_search_test.rb
@@ -36,7 +36,7 @@ class ProjectsSearchTest < ApplicationSystemTestCase
     find('input[data-search-target="input"]').fill_in with: "zzz-nothing"
 
     assert_text "No projects found"
-    assert_text '"zzz-nothing"'
+    assert_text "“zzz-nothing”"
 
     click_button "Clear search"
 

--- a/test/system/translation_editor_test.rb
+++ b/test/system/translation_editor_test.rb
@@ -36,11 +36,12 @@ class TranslationEditorTest < ApplicationSystemTestCase
 
     within ".locales-section" do
       click_button "New locale"
-      fill_in "Code", with: "fr"
-      click_button "Create"
+      # Multi-select combobox: type a custom IETF tag and press Enter to add it.
+      find('input[data-combobox-target="input"]').send_keys("fr", :enter)
+      click_button "Add languages"
     end
 
-    assert_text "Locale created."
+    assert_text "Added 1 locale"
     assert @project.locales.exists?(code: "fr")
   end
 end

--- a/test/system/translation_editor_test.rb
+++ b/test/system/translation_editor_test.rb
@@ -38,6 +38,7 @@ class TranslationEditorTest < ApplicationSystemTestCase
       click_button "New locale"
       # Multi-select combobox: type a custom IETF tag and press Enter to add it.
       find('input[data-combobox-target="input"]').send_keys("fr", :enter)
+      find("#new-locale-title").click # click outside the combobox to dismiss its dropdown
       click_button "Add languages"
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,29 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "fileutils"
 
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
+
+    # Materialized artifacts use deterministic storage keys (e.g.
+    # "main-app/common/en.json"), so every parallel worker would otherwise write
+    # to the SAME path under the shared tmp/storage and clobber each other. Give
+    # each Disk service its own per-worker root so blobs stay isolated.
+    parallelize_setup do |worker|
+      %i[ test local ].each do |name|
+        service = ActiveStorage::Blob.services.fetch(name) { nil }
+        next unless service.respond_to?(:root)
+
+        service.instance_variable_set(:@root, Rails.root.join("tmp/storage_#{name}_#{worker}").to_s)
+      end
+    end
+
+    parallelize_teardown do |worker|
+      %i[ test local ].each { |name| FileUtils.rm_rf(Rails.root.join("tmp/storage_#{name}_#{worker}")) }
+    end
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary

Closes the M5/M6 API + infra issues and delivers the "A Mono" workspace redesign.

### Features
- **API tokens** (`#42`) — per-project bearer auth, digest-only storage.
- **saveMissing inbox** (`#21`) — i18next reports unknown keys into a per-project triage inbox (`MissingKeyReport`); promote to a real key or ignore. New **Missing** project tab.
- **Rate limiting** (`#25`) — Rack::Attack with DB-configured limits (global `Setting` + per-project overrides).
- **Delivery path template** (`#77`) — deterministic Active Storage keys for artifacts; in-place blob upload, purge+re-key on template change.
- **Cloud backups** (`#78`) — scheduled per-project JSON snapshots to Active Storage (retention, download, restore); logic on `Project#create_backup!`, shallow job. New **Backups** project tab.
- **Storage connections** — workspace-level named references to Active Storage services; backups route to the default.
- **Members + Account** pages, restructured nav + user menu.
- **Dev seeds** (`#26`).

### Quality
- 288 tests, 0 failures · rubocop clean · brakeman 0 warnings.
- Adversarial review (multi-agent) → 6 correctness/security fixes applied (atomic hit counter, checksum-after-blob, saveMissing payload caps, restore integrity check, FK-race guard, backup dedup).
- Compass alignment pass → CRUD-noun routes, shallow jobs, `enqueue_after_transaction_commit`.

### Scope notes
- **`#22` / `#23`** saveMissing now records to an inbox instead of auto-creating keys/translations (per the redesign). Behavior diverges from the original issue text.
- **`#78`** reframed from a pg_dump DB backup to a **cloud translation backup**.

### Follow-ups
Spawned `#81`–`#92` for mockup features needing backend (machine translation, export CSV/XLIFF, review/approval, key drawer, QA checks, PATs, profile, CLI, storage-connection v2, invitations resend, snapshot streaming).

Closes #21
Closes #23
Closes #25
Closes #26
Closes #42
Closes #77
Closes #78
Refs #22