### PR TITLE
feat(export): export data-only (i18next/locize) + metadata opt-in

### DIFF
--- a/app/controllers/namespaces/exports_controller.rb
+++ b/app/controllers/namespaces/exports_controller.rb
@@ -7,6 +7,7 @@
 class Namespaces::ExportsController < ApplicationController
   include ProjectScoped
 
+  before_action :ensure_can_edit_translations
   before_action :set_namespace
 
   def show
@@ -26,7 +27,7 @@ class Namespaces::ExportsController < ApplicationController
     # Full-fidelity Snapshot for backup/restore (carries our metadata).
     def send_backup
       format = params[:as].to_s.presence_in(Snapshot::FORMATS) || "json"
-      body, content_type, ext = Snapshot.dump(namespace_snapshot, format: format)
+      body, content_type, ext = Snapshot.dump(TranslationSnapshot.build(@project, namespace: @namespace), format: format)
       send_data body, filename: "#{@project.slug}-#{@namespace.name}.#{ext}", type: content_type
     end
 
@@ -40,24 +41,5 @@ class Namespaces::ExportsController < ApplicationController
 
     def set_namespace
       @namespace = @project.namespaces.find_by!(name: params[:namespace_id])
-    end
-
-    # Canonical snapshot hash scoped to this one namespace, reusing the Snapshot
-    # serializers (every key, locale, value and published flag).
-    def namespace_snapshot
-      keys = {}
-      @namespace.translation_keys.order(:key).includes(translations: %i[ locale publication ]).each do |key|
-        entries = {}
-        key.translations.each do |translation|
-          entries[translation.locale.code] = { "value" => translation.value, "published" => translation.published? }
-        end
-        keys[key.key] = entries
-      end
-
-      {
-        "version" => TranslationSnapshot::VERSION,
-        "locales" => @project.locales.order(:code).pluck(:code),
-        "namespaces" => { @namespace.name => keys }
-      }
     end
 end

--- a/app/controllers/namespaces/exports_controller.rb
+++ b/app/controllers/namespaces/exports_controller.rb
@@ -1,16 +1,43 @@
-# Downloads a namespace's translations (all locales) in JSON / CSV / XLIFF.
+# Downloads a namespace's translations. Two modes:
+#   * default ("data") — clean, metadata-free values a client (i18next/locize) or
+#     our own import consumes: nested JSON / flat CSV, one file per locale (zipped
+#     when there's more than one). See NamespaceExport.
+#   * mode=backup — full-fidelity Snapshot (version + published flags) in JSON /
+#     CSV / XLIFF, for our own backup & restore.
 class Namespaces::ExportsController < ApplicationController
   include ProjectScoped
 
   before_action :set_namespace
 
   def show
-    format = params[:as].to_s.presence_in(Snapshot::FORMATS) || "json"
-    body, content_type, ext = Snapshot.dump(namespace_snapshot, format: format)
-    send_data body, filename: "#{@project.slug}-#{@namespace.name}.#{ext}", type: content_type
+    params[:mode] == "backup" ? send_backup : send_data_export
   end
 
   private
+    # Metadata-free, round-trippable, interop-friendly (locize/i18next).
+    def send_data_export
+      format = params[:as].to_s.presence_in(NamespaceExport::FORMATS) || "json"
+      file = NamespaceExport.new(@namespace, locales: selected_locales).download(format)
+      send_data file.body, filename: file.filename, type: file.content_type
+    rescue NamespaceExport::Error => e
+      redirect_to project_namespace_path(@project, @namespace), alert: e.message, status: :see_other
+    end
+
+    # Full-fidelity Snapshot for backup/restore (carries our metadata).
+    def send_backup
+      format = params[:as].to_s.presence_in(Snapshot::FORMATS) || "json"
+      body, content_type, ext = Snapshot.dump(namespace_snapshot, format: format)
+      send_data body, filename: "#{@project.slug}-#{@namespace.name}.#{ext}", type: content_type
+    end
+
+    # Optional ?locale= narrows a data export to one language (ideal for locize's
+    # per-language import); absent, every project locale is exported.
+    def selected_locales
+      return nil if params[:locale].blank?
+
+      @project.locales.where(code: params[:locale]).to_a
+    end
+
     def set_namespace
       @namespace = @project.namespaces.find_by!(name: params[:namespace_id])
     end

--- a/app/controllers/projects/exports_controller.rb
+++ b/app/controllers/projects/exports_controller.rb
@@ -1,0 +1,27 @@
+# Downloads a whole project's translations. Mirrors Namespaces::ExportsController:
+#   * default ("data") — clean, metadata-free files for every namespace × locale,
+#     laid out as "<locale>/<namespace>.<ext>" in a ZIP (i18next/locize-ready).
+#   * mode=backup — full-fidelity project Snapshot (version + published flags) in
+#     JSON / CSV / XLIFF, for our own backup & restore.
+class Projects::ExportsController < ApplicationController
+  include ProjectScoped
+
+  def show
+    params[:mode] == "backup" ? send_backup : send_data_export
+  end
+
+  private
+    def send_data_export
+      format = params[:as].to_s.presence_in(ProjectExport::FORMATS) || "json"
+      file = ProjectExport.new(@project).download(format)
+      send_data file.body, filename: file.filename, type: file.content_type
+    rescue NamespaceExport::Error => e
+      redirect_to project_path(@project), alert: e.message, status: :see_other
+    end
+
+    def send_backup
+      format = params[:as].to_s.presence_in(Snapshot::FORMATS) || "json"
+      body, content_type, ext = Snapshot.dump(TranslationSnapshot.build(@project), format: format)
+      send_data body, filename: "#{@project.slug}.#{ext}", type: content_type
+    end
+end

--- a/app/controllers/projects/exports_controller.rb
+++ b/app/controllers/projects/exports_controller.rb
@@ -6,6 +6,8 @@
 class Projects::ExportsController < ApplicationController
   include ProjectScoped
 
+  before_action :ensure_can_edit_translations
+
   def show
     params[:mode] == "backup" ? send_backup : send_data_export
   end

--- a/app/models/namespace_export.rb
+++ b/app/models/namespace_export.rb
@@ -18,7 +18,8 @@ require "zip"
 class NamespaceExport
   FORMATS = %w[ json csv ].freeze
 
-  File = Struct.new(:body, :content_type, :filename, keyword_init: true)
+  # A ready-to-send download: raw body plus how to serve it.
+  Download = Struct.new(:body, :content_type, :filename, keyword_init: true)
 
   class Error < StandardError; end
 
@@ -58,7 +59,7 @@ class NamespaceExport
 
     # One locale, one file — prefix it with project/namespace for a friendly name.
     def single(file)
-      File.new(body: file.body, content_type: file.content_type, filename: "#{prefix}-#{file.filename}")
+      Download.new(body: file.body, content_type: file.content_type, filename: "#{prefix}-#{file.filename}")
     end
 
     def zip(files, format)
@@ -68,14 +69,14 @@ class NamespaceExport
           zos.write(file.body)
         end
       end
-      File.new(body: buffer.string, content_type: "application/zip", filename: "#{prefix}-#{format}.zip")
+      Download.new(body: buffer.string, content_type: "application/zip", filename: "#{prefix}-#{format}.zip")
     end
 
     def file_for(locale, format)
       values = flat_values(locale)
       case format
-      when "json" then File.new(body: JSON.pretty_generate(nest(values)), content_type: "application/json", filename: "#{locale.code}.json")
-      when "csv"  then File.new(body: csv(values), content_type: "text/csv", filename: "#{locale.code}.csv")
+      when "json" then Download.new(body: JSON.pretty_generate(nest(values)), content_type: "application/json", filename: "#{locale.code}.json")
+      when "csv"  then Download.new(body: csv(values), content_type: "text/csv", filename: "#{locale.code}.csv")
       end
     end
 
@@ -91,7 +92,7 @@ class NamespaceExport
       scope = scope.published unless @include_drafts
 
       scope.each_with_object({}) { |t, h| h[t.translation_key.key] = t.value }
-           .sort.to_h
+           .sort_by(&:first).to_h
     end
 
     # Expand dotted keys into nested objects (inverse of TranslationImport#flatten).
@@ -111,7 +112,7 @@ class NamespaceExport
     end
 
     def csv(values)
-      ::CSV.generate do |out|
+      CSV.generate do |out|
         out << %w[ key value ]
         values.each { |key, value| out << [ key, value ] }
       end

--- a/app/models/namespace_export.rb
+++ b/app/models/namespace_export.rb
@@ -42,6 +42,15 @@ class NamespaceExport
     files.one? ? single(files.first) : zip(files, format)
   end
 
+  # Serialized body for one locale in the given format, without any packaging —
+  # lets a project-wide exporter reuse per-namespace rendering under its own paths.
+  def content(locale, format)
+    format = format.to_s
+    raise Error, "Unsupported data format #{format.inspect}" unless FORMATS.include?(format)
+
+    file_for(locale, format).body
+  end
+
   private
     def prefix
       "#{@namespace.project.slug}-#{@namespace.name}"

--- a/app/models/namespace_export.rb
+++ b/app/models/namespace_export.rb
@@ -1,0 +1,110 @@
+require "csv"
+require "zip"
+
+# Data-only export of a namespace: clean translation values per locale, with NO
+# Language Bridge metadata (no version, no published flags). The inverse of
+# TranslationImport: a file produced here re-imports losslessly, and the JSON
+# shape is the nested object an i18next client (or locize) consumes directly.
+#
+# This is deliberately distinct from Snapshot / TranslationSnapshot, which is the
+# full-fidelity *backup* format (carries version + published state for restore).
+# Use NamespaceExport for interop, Snapshot for backups.
+#
+#   * JSON — nested object, one file per locale ("home.title" -> {home:{title:..}})
+#   * CSV  — flat "key,value" rows, one file per locale
+#
+# A single locale downloads as one file; multiple locales are bundled into a ZIP
+# of "<locale>.<ext>" entries (the standard i18next per-language layout).
+class NamespaceExport
+  FORMATS = %w[ json csv ].freeze
+
+  File = Struct.new(:body, :content_type, :filename, keyword_init: true)
+
+  class Error < StandardError; end
+
+  # locales: the Locale records to export (defaults to all project locales).
+  # include_drafts: when true (default) every non-empty value is exported;
+  # when false only published values are, matching live delivery.
+  def initialize(namespace, locales: nil, include_drafts: true)
+    @namespace = namespace
+    @locales = locales || namespace.project.locales.order(:code).to_a
+    @include_drafts = include_drafts
+  end
+
+  # Returns a File (body, content_type, filename) for the given format. One file
+  # per locale collapses to a single download; many locales zip together.
+  def download(format)
+    format = format.to_s
+    raise Error, "Unsupported data format #{format.inspect}" unless FORMATS.include?(format)
+    raise Error, "No locales to export" if @locales.empty?
+
+    files = @locales.map { |locale| file_for(locale, format) }
+    files.one? ? single(files.first) : zip(files, format)
+  end
+
+  private
+    def prefix
+      "#{@namespace.project.slug}-#{@namespace.name}"
+    end
+
+    # One locale, one file — prefix it with project/namespace for a friendly name.
+    def single(file)
+      File.new(body: file.body, content_type: file.content_type, filename: "#{prefix}-#{file.filename}")
+    end
+
+    def zip(files, format)
+      buffer = Zip::OutputStream.write_buffer do |zos|
+        files.each do |file|
+          zos.put_next_entry(file.filename)
+          zos.write(file.body)
+        end
+      end
+      File.new(body: buffer.string, content_type: "application/zip", filename: "#{prefix}-#{format}.zip")
+    end
+
+    def file_for(locale, format)
+      values = flat_values(locale)
+      case format
+      when "json" then File.new(body: JSON.pretty_generate(nest(values)), content_type: "application/json", filename: "#{locale.code}.json")
+      when "csv"  then File.new(body: csv(values), content_type: "text/csv", filename: "#{locale.code}.csv")
+      end
+    end
+
+    # { "dotted.key" => value } for one locale, skipping empty values. Includes
+    # drafts unless include_drafts is false. Keys sorted for stable diffs.
+    def flat_values(locale)
+      scope = Translation
+        .where(locale: locale)
+        .joins(:translation_key)
+        .where(translation_keys: { namespace_id: @namespace.id })
+        .where.not(value: [ nil, "" ])
+        .includes(:translation_key)
+      scope = scope.published unless @include_drafts
+
+      scope.each_with_object({}) { |t, h| h[t.translation_key.key] = t.value }
+           .sort.to_h
+    end
+
+    # Expand dotted keys into nested objects (inverse of TranslationImport#flatten).
+    def nest(values)
+      values.each_with_object({}) do |(key, value), tree|
+        insert(tree, key.split("."), value)
+      end
+    end
+
+    def insert(tree, segments, value)
+      leaf = segments.pop
+      node = segments.reduce(tree) do |hash, segment|
+        hash[segment] = {} unless hash[segment].is_a?(Hash)
+        hash[segment]
+      end
+      node[leaf] = value
+    end
+
+    def csv(values)
+      ::CSV.generate do |out|
+        out << %w[ key value ]
+        values.each { |key, value| out << [ key, value ] }
+      end
+    end
+end

--- a/app/models/project_export.rb
+++ b/app/models/project_export.rb
@@ -1,0 +1,53 @@
+require "zip"
+
+# Data-only export of an entire project: every namespace × locale rendered as
+# clean, metadata-free files and bundled into one ZIP, laid out the way an
+# i18next/locize client loads them — "<locale>/<namespace>.<ext>" (the same shape
+# as the delivery loadPath "/cdn/:project/:locale/:namespace.json").
+#
+# Delegates per-namespace serialization to NamespaceExport (see it for format,
+# draft and round-trip semantics). For a single namespace use NamespaceExport;
+# for a full-fidelity backup of the project use TranslationSnapshot / Snapshot.
+class ProjectExport
+  FORMATS = NamespaceExport::FORMATS
+
+  def initialize(project, include_drafts: true)
+    @project = project
+    @include_drafts = include_drafts
+    @locales = project.locales.order(:code).to_a
+    @namespaces = project.namespaces.order(:name).to_a
+  end
+
+  # Returns a NamespaceExport::File (body, content_type, filename): always a ZIP.
+  # Namespaces with no values for a given locale are skipped (no empty entries).
+  def download(format)
+    format = format.to_s
+    raise NamespaceExport::Error, "Unsupported data format #{format.inspect}" unless FORMATS.include?(format)
+    raise NamespaceExport::Error, "Nothing to export" if @locales.empty? || @namespaces.empty?
+
+    buffer = Zip::OutputStream.write_buffer do |zos|
+      @namespaces.each do |namespace|
+        exporter = NamespaceExport.new(namespace, locales: @locales, include_drafts: @include_drafts)
+        @locales.each do |locale|
+          body = exporter.content(locale, format)
+          next if empty?(body, format)
+
+          zos.put_next_entry("#{locale.code}/#{namespace.name}.#{format}")
+          zos.write(body)
+        end
+      end
+    end
+
+    NamespaceExport::File.new(body: buffer.string, content_type: "application/zip", filename: "#{@project.slug}-#{format}.zip")
+  end
+
+  private
+    # A namespace with no translated values for a locale renders to just an empty
+    # object / a header-only CSV — skip it rather than ship a useless file.
+    def empty?(body, format)
+      case format
+      when "json" then JSON.parse(body).empty?
+      when "csv"  then body.strip.lines.size <= 1
+      end
+    end
+end

--- a/app/models/project_export.rb
+++ b/app/models/project_export.rb
@@ -18,8 +18,8 @@ class ProjectExport
     @namespaces = project.namespaces.order(:name).to_a
   end
 
-  # Returns a NamespaceExport::File (body, content_type, filename): always a ZIP.
-  # Namespaces with no values for a given locale are skipped (no empty entries).
+  # Returns a NamespaceExport::Download (body, content_type, filename): always a
+  # ZIP. Namespaces with no values for a given locale are skipped (no empty files).
   def download(format)
     format = format.to_s
     raise NamespaceExport::Error, "Unsupported data format #{format.inspect}" unless FORMATS.include?(format)
@@ -38,7 +38,7 @@ class ProjectExport
       end
     end
 
-    NamespaceExport::File.new(body: buffer.string, content_type: "application/zip", filename: "#{@project.slug}-#{format}.zip")
+    NamespaceExport::Download.new(body: buffer.string, content_type: "application/zip", filename: "#{@project.slug}-#{format}.zip")
   end
 
   private

--- a/app/models/translation_snapshot.rb
+++ b/app/models/translation_snapshot.rb
@@ -8,13 +8,16 @@ class TranslationSnapshot
 
   class FormatError < StandardError; end
 
-  def self.build(project, include_drafts: true)
-    new(project, include_drafts:).build
+  # Pass namespace: to scope the snapshot to a single namespace (e.g. a namespace
+  # export); omit it for the whole project.
+  def self.build(project, include_drafts: true, namespace: nil)
+    new(project, include_drafts:, namespace:).build
   end
 
-  def initialize(project, include_drafts: true)
+  def initialize(project, include_drafts: true, namespace: nil)
     @project = project
     @include_drafts = include_drafts
+    @namespace = namespace
   end
 
   def build
@@ -60,8 +63,9 @@ class TranslationSnapshot
   private
     def namespaces_hash
       result = {}
-      @project.namespaces.order(:name)
-              .includes(translation_keys: { translations: %i[ locale publication ] }).each do |namespace|
+      scope = @project.namespaces.order(:name).includes(translation_keys: { translations: %i[ locale publication ] })
+      scope = scope.where(id: @namespace.id) if @namespace
+      scope.each do |namespace|
         keys = {}
         namespace.translation_keys.sort_by(&:key).each do |translation_key|
           entries = {}

--- a/app/views/namespaces/show.html.erb
+++ b/app/views/namespaces/show.html.erb
@@ -42,11 +42,11 @@
       <% end %>
 
       <% if @locales.any? %>
-        <% row = "flex items-center gap-[9px] px-[10px] py-2 rounded-[7px] text-[13px] text-ink hover:bg-surface-2" %>
-        <% tag = "font-mono text-[11px] text-mut-2 w-[42px]" %>
+        <% row = "flex items-center gap-[10px] px-[11px] py-[9px] rounded-[7px] text-[13.5px] text-ink hover:bg-surface-2" %>
+        <% tag = "font-mono text-[11.5px] text-mut-2 w-[48px]" %>
         <details class="relative [&_summary::-webkit-details-marker]:hidden">
           <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
-          <div class="absolute top-[calc(100%+6px)] right-0 w-[220px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[5px]">
+          <div class="absolute top-[calc(100%+6px)] right-0 w-[280px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[6px]">
             <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
             <% NamespaceExport::FORMATS.each do |fmt| %>
               <%= link_to project_namespace_export_path(@project, @namespace, as: fmt), data: { turbo: false }, class: row do %>

--- a/app/views/namespaces/show.html.erb
+++ b/app/views/namespaces/show.html.erb
@@ -42,14 +42,30 @@
       <% end %>
 
       <% if @locales.any? %>
+        <% row = "flex items-center gap-[9px] px-[10px] py-2 rounded-[7px] text-[13px] text-ink hover:bg-surface-2" %>
+        <% tag = "font-mono text-[11px] text-mut-2 w-[42px]" %>
         <details class="relative [&_summary::-webkit-details-marker]:hidden">
           <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
-          <div class="absolute top-[calc(100%+6px)] right-0 w-[190px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[5px]">
-            <div class="px-[10px] py-[7px] eyebrow">Download namespace</div>
+          <div class="absolute top-[calc(100%+6px)] right-0 w-[220px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[5px]">
+            <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
+            <% NamespaceExport::FORMATS.each do |fmt| %>
+              <%= link_to project_namespace_export_path(@project, @namespace, as: fmt), data: { turbo: false }, class: row do %>
+                <span class="<%= tag %>"><%= fmt.upcase %></span><%= @locales.size > 1 ? "All locales (.zip)" : "Download" %>
+              <% end %>
+            <% end %>
+            <% if @locales.size > 1 %>
+              <div class="px-[10px] pt-[8px] pb-[3px] eyebrow">JSON by locale</div>
+              <% @locales.each do |locale| %>
+                <%= link_to project_namespace_export_path(@project, @namespace, as: "json", locale: locale.code), data: { turbo: false }, class: row do %>
+                  <span class="<%= tag %>"><%= locale.code %></span>.json
+                <% end %>
+              <% end %>
+            <% end %>
+            <div class="my-[5px] border-t border-line"></div>
+            <div class="px-[10px] py-[7px] eyebrow">Backup — with metadata</div>
             <% Snapshot::FORMATS.each do |fmt| %>
-              <%= link_to project_namespace_export_path(@project, @namespace, as: fmt), data: { turbo: false },
-                    class: "flex items-center gap-[9px] px-[10px] py-2 rounded-[7px] text-[13px] text-ink hover:bg-surface-2" do %>
-                <span class="font-mono text-[11px] text-mut-2 w-[42px]"><%= fmt.upcase %></span>Download
+              <%= link_to project_namespace_export_path(@project, @namespace, as: fmt, mode: "backup"), data: { turbo: false }, class: row do %>
+                <span class="<%= tag %>"><%= fmt.upcase %></span>Download
               <% end %>
             <% end %>
           </div>

--- a/app/views/namespaces/show.html.erb
+++ b/app/views/namespaces/show.html.erb
@@ -41,35 +41,18 @@
         </span>
       <% end %>
 
-      <% if @locales.any? %>
-        <% row = "flex items-center gap-[10px] px-[11px] py-[9px] rounded-[7px] text-[13.5px] text-ink hover:bg-surface-2" %>
-        <% tag = "font-mono text-[11.5px] text-mut-2 w-[48px]" %>
-        <details class="relative [&_summary::-webkit-details-marker]:hidden">
-          <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
-          <div class="absolute top-[calc(100%+6px)] right-0 w-[280px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[6px]">
-            <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
-            <% NamespaceExport::FORMATS.each do |fmt| %>
-              <%= link_to project_namespace_export_path(@project, @namespace, as: fmt), data: { turbo: false }, class: row do %>
-                <span class="<%= tag %>"><%= fmt.upcase %></span><%= @locales.size > 1 ? "All locales (.zip)" : "Download" %>
-              <% end %>
-            <% end %>
-            <% if @locales.size > 1 %>
-              <div class="px-[10px] pt-[8px] pb-[3px] eyebrow">JSON by locale</div>
-              <% @locales.each do |locale| %>
-                <%= link_to project_namespace_export_path(@project, @namespace, as: "json", locale: locale.code), data: { turbo: false }, class: row do %>
-                  <span class="<%= tag %>"><%= locale.code %></span>.json
-                <% end %>
-              <% end %>
-            <% end %>
-            <div class="my-[5px] border-t border-line"></div>
-            <div class="px-[10px] py-[7px] eyebrow">Backup — with metadata</div>
-            <% Snapshot::FORMATS.each do |fmt| %>
-              <%= link_to project_namespace_export_path(@project, @namespace, as: fmt, mode: "backup"), data: { turbo: false }, class: row do %>
-                <span class="<%= tag %>"><%= fmt.upcase %></span>Download
-              <% end %>
-            <% end %>
-          </div>
-        </details>
+      <% if editable && @locales.any? %>
+        <%= render "shared/export_menu",
+              data_links: NamespaceExport::FORMATS.map { |fmt| {
+                tag: fmt.upcase, label: (@locales.size > 1 ? "All locales (.zip)" : "Download"),
+                url: project_namespace_export_path(@project, @namespace, as: fmt) } },
+              per_locale_title: "JSON by locale",
+              per_locale_links: (@locales.size > 1 ? @locales.map { |locale| {
+                tag: locale.code, label: ".json",
+                url: project_namespace_export_path(@project, @namespace, as: "json", locale: locale.code) } } : []),
+              backup_links: Snapshot::FORMATS.map { |fmt| {
+                tag: fmt.upcase, label: "Download",
+                url: project_namespace_export_path(@project, @namespace, as: fmt, mode: "backup") } } %>
       <% end %>
 
       <% if manageable && @locales.any? %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -67,9 +67,33 @@
         <h3 class="m-0 text-[16px] font-semibold text-ink">Namespaces</h3>
         <span class="font-mono text-[12px] text-faint"><%= format("%02d", @namespaces.size) %></span>
       </div>
-      <% if current_user.admin? %>
-        <button type="button" class="btn h-[34px]" data-action="click->modal#open"><%= mi "add", size: 17, weight: 400 %>New namespace</button>
-      <% end %>
+      <div class="flex items-center gap-[9px]">
+        <% if @namespaces.any? && @locales.any? %>
+          <% row = "flex items-center gap-[9px] px-[10px] py-2 rounded-[7px] text-[13px] text-ink hover:bg-surface-2" %>
+          <% tag = "font-mono text-[11px] text-mut-2 w-[42px]" %>
+          <details class="relative [&_summary::-webkit-details-marker]:hidden">
+            <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
+            <div class="absolute top-[calc(100%+6px)] right-0 w-[230px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[5px]">
+              <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
+              <% ProjectExport::FORMATS.each do |fmt| %>
+                <%= link_to project_export_path(@project, as: fmt), data: { turbo: false }, class: row do %>
+                  <span class="<%= tag %>"><%= fmt.upcase %></span>All namespaces (.zip)
+                <% end %>
+              <% end %>
+              <div class="my-[5px] border-t border-line"></div>
+              <div class="px-[10px] py-[7px] eyebrow">Backup — with metadata</div>
+              <% Snapshot::FORMATS.each do |fmt| %>
+                <%= link_to project_export_path(@project, as: fmt, mode: "backup"), data: { turbo: false }, class: row do %>
+                  <span class="<%= tag %>"><%= fmt.upcase %></span>Download
+                <% end %>
+              <% end %>
+            </div>
+          </details>
+        <% end %>
+        <% if current_user.admin? %>
+          <button type="button" class="btn h-[34px]" data-action="click->modal#open"><%= mi "add", size: 17, weight: 400 %>New namespace</button>
+        <% end %>
+      </div>
     </div>
 
     <% if current_user.admin? %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -69,11 +69,11 @@
       </div>
       <div class="flex items-center gap-[9px]">
         <% if @namespaces.any? && @locales.any? %>
-          <% row = "flex items-center gap-[9px] px-[10px] py-2 rounded-[7px] text-[13px] text-ink hover:bg-surface-2" %>
-          <% tag = "font-mono text-[11px] text-mut-2 w-[42px]" %>
+          <% row = "flex items-center gap-[10px] px-[11px] py-[9px] rounded-[7px] text-[13.5px] text-ink hover:bg-surface-2" %>
+          <% tag = "font-mono text-[11.5px] text-mut-2 w-[48px]" %>
           <details class="relative [&_summary::-webkit-details-marker]:hidden">
             <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
-            <div class="absolute top-[calc(100%+6px)] right-0 w-[230px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[5px]">
+            <div class="absolute top-[calc(100%+6px)] right-0 w-[280px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[6px]">
               <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
               <% ProjectExport::FORMATS.each do |fmt| %>
                 <%= link_to project_export_path(@project, as: fmt), data: { turbo: false }, class: row do %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -68,27 +68,15 @@
         <span class="font-mono text-[12px] text-faint"><%= format("%02d", @namespaces.size) %></span>
       </div>
       <div class="flex items-center gap-[9px]">
-        <% if @namespaces.any? && @locales.any? %>
-          <% row = "flex items-center gap-[10px] px-[11px] py-[9px] rounded-[7px] text-[13.5px] text-ink hover:bg-surface-2" %>
-          <% tag = "font-mono text-[11.5px] text-mut-2 w-[48px]" %>
-          <details class="relative [&_summary::-webkit-details-marker]:hidden">
-            <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
-            <div class="absolute top-[calc(100%+6px)] right-0 w-[280px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[6px]">
-              <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
-              <% ProjectExport::FORMATS.each do |fmt| %>
-                <%= link_to project_export_path(@project, as: fmt), data: { turbo: false }, class: row do %>
-                  <span class="<%= tag %>"><%= fmt.upcase %></span>All namespaces (.zip)
-                <% end %>
-              <% end %>
-              <div class="my-[5px] border-t border-line"></div>
-              <div class="px-[10px] py-[7px] eyebrow">Backup — with metadata</div>
-              <% Snapshot::FORMATS.each do |fmt| %>
-                <%= link_to project_export_path(@project, as: fmt, mode: "backup"), data: { turbo: false }, class: row do %>
-                  <span class="<%= tag %>"><%= fmt.upcase %></span>Download
-                <% end %>
-              <% end %>
-            </div>
-          </details>
+        <% if current_user.can_edit_translations?(@project) && @namespaces.any? && @locales.any? %>
+          <%= render "shared/export_menu",
+                data_links: ProjectExport::FORMATS.map { |fmt| {
+                  tag: fmt.upcase, label: "All namespaces (.zip)",
+                  url: project_export_path(@project, as: fmt) } },
+                per_locale_title: nil, per_locale_links: [],
+                backup_links: Snapshot::FORMATS.map { |fmt| {
+                  tag: fmt.upcase, label: "Download",
+                  url: project_export_path(@project, as: fmt, mode: "backup") } } %>
         <% end %>
         <% if current_user.admin? %>
           <button type="button" class="btn h-[34px]" data-action="click->modal#open"><%= mi "add", size: 17, weight: 400 %>New namespace</button>

--- a/app/views/shared/_export_menu.html.erb
+++ b/app/views/shared/_export_menu.html.erb
@@ -1,0 +1,34 @@
+<%# Export dropdown shared by the namespace and project pages.
+    Locals (all explicit):
+      data_links       — [{ tag:, label:, url: }] clean, metadata-free exports
+      backup_links     — [{ tag:, label:, url: }] full-fidelity snapshot exports
+      per_locale_links — [{ tag:, label:, url: }] optional per-locale shortcuts ([] to omit)
+      per_locale_title — heading for the per-locale group %>
+<% row = "flex items-center gap-[10px] px-[11px] py-[9px] rounded-[7px] text-[13.5px] text-ink hover:bg-surface-2" %>
+<% tag_cls = "font-mono text-[11.5px] text-mut-2 w-[48px]" %>
+<details class="relative [&_summary::-webkit-details-marker]:hidden">
+  <summary class="list-none cursor-pointer btn-secondary h-[34px]"><%= mi "upload", size: 17, css: "text-ink-3" %>Export<%= mi "expand_more", size: 16, css: "text-faint" %></summary>
+  <div class="absolute top-[calc(100%+6px)] right-0 w-[280px] bg-surface border border-line rounded-[10px] shadow-[0_10px_30px_-10px_rgba(15,23,42,0.22)] z-40 p-[6px]">
+    <div class="px-[10px] py-[7px] eyebrow">Data — i18next / locize</div>
+    <% data_links.each do |link| %>
+      <%= link_to link[:url], data: { turbo: false }, class: row do %>
+        <span class="<%= tag_cls %>"><%= link[:tag] %></span><%= link[:label] %>
+      <% end %>
+    <% end %>
+    <% if per_locale_links.present? %>
+      <div class="px-[10px] pt-[8px] pb-[3px] eyebrow"><%= per_locale_title %></div>
+      <% per_locale_links.each do |link| %>
+        <%= link_to link[:url], data: { turbo: false }, class: row do %>
+          <span class="<%= tag_cls %>"><%= link[:tag] %></span><%= link[:label] %>
+        <% end %>
+      <% end %>
+    <% end %>
+    <div class="my-[5px] border-t border-line"></div>
+    <div class="px-[10px] py-[7px] eyebrow">Backup — with metadata</div>
+    <% backup_links.each do |link| %>
+      <%= link_to link[:url], data: { turbo: false }, class: row do %>
+        <span class="<%= tag_cls %>"><%= link[:tag] %></span><%= link[:label] %>
+      <% end %>
+    <% end %>
+  </div>
+</details>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
       resource :restoration, only: :create, controller: "projects/backups/restorations"
     end
     resource :backup_schedule, only: :update, controller: "projects/backup_schedules"
+    resource :export, only: :show, controller: "projects/exports"
     resources :locales, only: %i[ create update destroy ] do
       member { post :source }
     end

--- a/test/controllers/namespaces/exports_controller_test.rb
+++ b/test/controllers/namespaces/exports_controller_test.rb
@@ -52,4 +52,10 @@ class Namespaces::ExportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "namespace,key,locale,value,published", response.body
   end
+
+  test "a viewer cannot export (drafts must not leak)" do
+    sign_in_as(users(:viewer))
+    get project_namespace_export_path(@project, @namespace, as: "json", locale: "en")
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/namespaces/exports_controller_test.rb
+++ b/test/controllers/namespaces/exports_controller_test.rb
@@ -4,19 +4,51 @@ class Namespaces::ExportsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @project = projects(:main_app)
     @namespace = namespaces(:main_app_common)
+    sign_in_as(users(:translator))
   end
 
-  test "downloads the namespace as JSON" do
-    sign_in_as(users(:translator))
-    get project_namespace_export_path(@project, @namespace, as: "json")
+  # ---- data export (default: clean, metadata-free) ----
+
+  test "data JSON for a single locale is nested and metadata-free" do
+    get project_namespace_export_path(@project, @namespace, as: "json", locale: "en")
     assert_response :success
     assert_equal "application/json", response.media_type
     assert_match(/attachment/, response.headers["Content-Disposition"])
+
+    data = JSON.parse(response.body)
+    assert_equal "Hello", data["greeting"]
+    assert_not data.key?("version")     # no snapshot metadata
+    assert_not data.key?("farewell")    # empty value omitted
   end
 
-  test "downloads the namespace as CSV" do
-    sign_in_as(users(:translator))
-    get project_namespace_export_path(@project, @namespace, as: "csv")
+  test "data JSON across multiple locales downloads a zip" do
+    get project_namespace_export_path(@project, @namespace, as: "json")
+    assert_response :success
+    assert_equal "application/zip", response.media_type
+    assert_match(/\.zip/, response.headers["Content-Disposition"])
+  end
+
+  test "data CSV for a single locale is a flat key,value file" do
+    get project_namespace_export_path(@project, @namespace, as: "csv", locale: "en")
+    assert_response :success
+    assert_equal "text/csv", response.media_type
+    assert_match "key,value", response.body
+    assert_match "greeting,Hello", response.body
+    assert_no_match(/published/, response.body)
+  end
+
+  # ---- backup export (opt-in: full-fidelity with metadata) ----
+
+  test "backup JSON carries snapshot metadata" do
+    get project_namespace_export_path(@project, @namespace, as: "json", mode: "backup")
+    assert_response :success
+    assert_equal "application/json", response.media_type
+    data = JSON.parse(response.body)
+    assert_equal TranslationSnapshot::VERSION, data["version"]
+  end
+
+  test "backup CSV keeps the metadata columns" do
+    get project_namespace_export_path(@project, @namespace, as: "csv", mode: "backup")
     assert_response :success
     assert_match "namespace,key,locale,value,published", response.body
   end

--- a/test/controllers/projects/exports_controller_test.rb
+++ b/test/controllers/projects/exports_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Projects::ExportsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @project = projects(:main_app)
+    sign_in_as(users(:translator))
+  end
+
+  test "data export bundles the whole project as a zip" do
+    get project_export_path(@project, as: "json")
+    assert_response :success
+    assert_equal "application/zip", response.media_type
+    assert_match(/attachment/, response.headers["Content-Disposition"])
+    assert_match(/main-app-json\.zip/, response.headers["Content-Disposition"])
+  end
+
+  test "backup export dumps the full project snapshot with metadata" do
+    get project_export_path(@project, as: "json", mode: "backup")
+    assert_response :success
+    assert_equal "application/json", response.media_type
+    data = JSON.parse(response.body)
+    assert_equal TranslationSnapshot::VERSION, data["version"]
+    assert data["namespaces"].key?("common")
+  end
+end

--- a/test/controllers/projects/exports_controller_test.rb
+++ b/test/controllers/projects/exports_controller_test.rb
@@ -22,4 +22,10 @@ class Projects::ExportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal TranslationSnapshot::VERSION, data["version"]
     assert data["namespaces"].key?("common")
   end
+
+  test "a viewer cannot export (drafts must not leak)" do
+    sign_in_as(users(:viewer))
+    get project_export_path(@project, as: "json")
+    assert_response :forbidden
+  end
 end

--- a/test/models/namespace_export_test.rb
+++ b/test/models/namespace_export_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "zip"
+
+class NamespaceExportTest < ActiveSupport::TestCase
+  setup do
+    @project = projects(:main_app)
+    @namespace = namespaces(:main_app_common)
+    @en = locales(:main_app_en)
+    @pt = locales(:main_app_pt_br)
+  end
+
+  test "JSON expands dotted keys into nested objects" do
+    key = @namespace.translation_keys.create!(project: @project, key: "home.title")
+    Translation.create!(project: @project, translation_key: key, locale: @en, value: "Welcome")
+
+    file = NamespaceExport.new(@namespace, locales: [ @en ]).download("json")
+    data = JSON.parse(file.body)
+
+    assert_equal "Welcome", data.dig("home", "title")
+    assert_equal "Hello", data["greeting"]
+  end
+
+  test "empty values are omitted" do
+    file = NamespaceExport.new(@namespace, locales: [ @en ]).download("json")
+    data = JSON.parse(file.body)
+
+    assert_not data.key?("farewell") # farewell_en_missing has a blank value
+  end
+
+  test "multiple locales bundle into a zip of per-locale files" do
+    file = NamespaceExport.new(@namespace, locales: [ @en, @pt ]).download("json")
+    assert_equal "application/zip", file.content_type
+
+    entries = {}
+    Zip::InputStream.open(StringIO.new(file.body)) do |io|
+      while (entry = io.get_next_entry)
+        entries[entry.name] = io.read
+      end
+    end
+
+    assert_equal %w[ en.json pt-BR.json ], entries.keys.sort
+    assert_equal "Olá", JSON.parse(entries["pt-BR.json"])["greeting"]
+  end
+
+  test "export round-trips back through TranslationImport" do
+    body = NamespaceExport.new(@namespace, locales: [ @en ]).download("json").body
+
+    # Re-importing the exported file leaves the value intact.
+    TranslationImport.new(namespace: @namespace, locale: @en, author: users(:translator), format: "json").import(body)
+
+    value = @namespace.translation_keys.find_by(key: "greeting").translations.find_by(locale: @en).value
+    assert_equal "Hello", value
+  end
+
+  test "unsupported format raises" do
+    assert_raises(NamespaceExport::Error) do
+      NamespaceExport.new(@namespace, locales: [ @en ]).download("yaml")
+    end
+  end
+end

--- a/test/models/project_export_test.rb
+++ b/test/models/project_export_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "zip"
+
+class ProjectExportTest < ActiveSupport::TestCase
+  setup do
+    @project = projects(:main_app)
+  end
+
+  def entries(format)
+    body = ProjectExport.new(@project).download(format).body
+    map = {}
+    Zip::InputStream.open(StringIO.new(body)) do |io|
+      while (entry = io.get_next_entry)
+        map[entry.name] = io.read
+      end
+    end
+    map
+  end
+
+  test "bundles every namespace x locale under <locale>/<namespace>.<ext>" do
+    files = entries("json")
+
+    assert_includes files.keys, "en/common.json"
+    assert_includes files.keys, "pt-BR/common.json"
+    assert_equal "Hello", JSON.parse(files["en/common.json"])["greeting"]
+    assert_equal "Olá", JSON.parse(files["pt-BR/common.json"])["greeting"]
+  end
+
+  test "namespaces with no values for a locale are skipped" do
+    # main_app_marketing has no translations in fixtures -> no entries for it.
+    assert_empty entries("json").keys.grep(%r{/marketing\.json\z})
+  end
+
+  test "download is always a zip" do
+    file = ProjectExport.new(@project).download("json")
+    assert_equal "application/zip", file.content_type
+    assert_equal "main-app-json.zip", file.filename
+  end
+
+  test "unsupported format raises" do
+    assert_raises(NamespaceExport::Error) { ProjectExport.new(@project).download("yaml") }
+  end
+end


### PR DESCRIPTION
## O quê

Torna o **export padrão** de namespace **limpo, sem metadata nosso** — pronto pra importar no **locize / i18next** e re-importável por nós mesmos. Metadata (`version`, `published`) vira **opt-in** via `?mode=backup`.

Fecha o item **P0** do roadmap de formatos (#99).

## Por quê

Antes, o botão Export cuspia o shape de **snapshot** (`{version, locales, namespaces:{k:{locale:{value,published}}}}`) — com metadata, flat, multi-locale. Esse arquivo **nem o próprio import aceitava** (import espera `{key:value}` por locale) nem entrava em ferramentas de mercado. Round-trip quebrado.

## Como

- **Novo `NamespaceExport`** (`app/models/namespace_export.rb`): valores limpos por locale.
  - **JSON** → objeto **nested** (i18next): `{"home":{"title":"…"}}`.
  - **CSV** → `key,value` flat.
  - 1 locale → arquivo único; N locales → **ZIP** de `<locale>.<ext>` (layout i18next).
  - Inclui drafts por padrão (`include_drafts`); só valores não-vazios; keys ordenadas.
- **`Namespaces::ExportsController`** ramifica:
  - default → `send_data_export` (limpo, interop).
  - `?mode=backup` → `Snapshot` (full-fidelity, restore).
  - `?locale=xx` opcional → 1 idioma só (ideal pro import per-language do locize).
- **UI** (`namespaces/show.html.erb`): menu Export com dois grupos — **Data (i18next/locize)** + **por-locale** e **Backup (with metadata)**.
- **Round-trip garantido**: `TranslationImport#flatten` já converte nested→dotted. Teste cobre export→import.

## Testes

```
10 runs, 33 assertions, 0 failures  (export)
22 runs, 65 assertions, 0 failures  (import/snapshot — sem regressão)
```

Verificado também no server dev: `main-app-common-en.json` sai nested (`{"common":{"welcome":"Welcome",…}}`), ZIP multi-locale ok.

## Escopo / follow-up

- Data-mode cobre **JSON + CSV**. XLIFF continua pelo caminho backup/snapshot (já é round-trippável).
- Demais formatos de mercado (Rails YAML, iOS, Android, gettext, ARB…) → roadmap em #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
