### PR TITLE
feat: docker & kubernetes deploy + configurable delivery base URL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,8 @@
 # Ignore Docker-related files
 /.dockerignore
 /Dockerfile*
+/compose*.yml
+/docker-compose*.yml
+
+# Ignore Kubernetes manifests.
+/k8s/

--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,65 @@
-# Copy to .env (gitignored) and fill in real values for local dev.
+# Copy to .env (gitignored) and fill in real values.
+# Used by dotenv in development, and as the reference for the vars a production
+# container (Docker / Kubernetes) expects. Generate secrets with:
+#   bin/rails secret                        # SECRET_KEY_BASE
+#   bin/rails db:encryption:init            # the three AR_ENCRYPTION_* keys
 
-# Server
+# ── Core secrets (REQUIRED in production) ────────────────────────────────────
+# Provide EITHER SECRET_KEY_BASE (recommended for 12-factor) OR RAILS_MASTER_KEY.
+SECRET_KEY_BASE=
+# RAILS_MASTER_KEY=
+
+# ActiveRecord encryption keys (encrypt storage-connection credentials at rest).
+# Required in production; auto-derived from secret_key_base in dev/test.
+AR_ENCRYPTION_PRIMARY_KEY=
+AR_ENCRYPTION_DETERMINISTIC_KEY=
+AR_ENCRYPTION_KEY_DERIVATION_SALT=
+
+# ── Rails runtime ────────────────────────────────────────────────────────────
+RAILS_ENV=production
 PORT=3001
+RAILS_LOG_LEVEL=info
+# Puma processes (workers) and threads per worker.
+WEB_CONCURRENCY=2
+RAILS_MAX_THREADS=3
 
-# Database (used by config/database.yml fallbacks)
+# ── HTTP / TLS / host ────────────────────────────────────────────────────────
+# Canonical host used for mailer links and (optionally) host authorization.
+APP_HOST=example.com
+# Comma-separated allowlist for DNS-rebinding protection. Leading "." = wildcard
+# subdomain (".example.com"). Empty = allow all (fine behind a trusted ingress).
+RAILS_HOSTS=
+# TLS is terminated by the ingress/proxy in front of the app by default.
+RAILS_ASSUME_SSL=true
+RAILS_FORCE_SSL=true
+
+# ── Database (external Postgres) ─────────────────────────────────────────────
+# The app uses 4 databases on this host (primary + Solid cache/queue/cable);
+# db:prepare creates them. Point DB_HOST at your managed/external Postgres.
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
+# Production primary connects as user "back" with this password.
+BACK_DATABASE_PASSWORD=
 
-# Mailer (Resend SMTP)
+# Run db:prepare (create + migrate) on container boot. Set false for the web/job
+# pods in Kubernetes and migrate via the one-shot migrate Job instead.
+RUN_DB_PREPARE=true
+
+# ── Background jobs (Solid Queue) ────────────────────────────────────────────
+# true = run the job supervisor inside Puma (single deployment, simplest).
+# false = run jobs in a dedicated `bin/jobs` process/deployment.
+SOLID_QUEUE_IN_PUMA=true
+JOB_CONCURRENCY=1
+
+# ── Mailer (Resend SMTP by default) ──────────────────────────────────────────
 SMTP_HOST=smtp.resend.com
 SMTP_PORT=465
 SMTP_USERNAME=resend
 SMTP_PASSWORD=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 MAIL_FROM=Language Bridge <onboarding@resend.dev>
+
+# ── Machine translation ──────────────────────────────────────────────────────
+# stub (offline default) | provider key once real providers are wired up.
+MT_PROVIDER=stub

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Build & publish image
+
+# Builds the production Docker image and pushes it to GitHub Container Registry
+# (ghcr.io/<owner>/<repo>). Triggers on version tags (v1.2.3) and manual runs.
+on:
+  push:
+    tags: [ "v*" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,11 @@ COPY --chown=rails:rails --from=build /rails /rails
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
+# Container-level health check hitting the Rails /up endpoint (also used by
+# Kubernetes probes and docker-compose healthchecks).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl -fsS http://localhost:80/up || exit 1
+
 # Start server via Thruster by default, this can be overwritten at runtime
 EXPOSE 80
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/app/controllers/workspace_controller.rb
+++ b/app/controllers/workspace_controller.rb
@@ -26,6 +26,7 @@ class WorkspaceController < ApplicationController
         :delivery_rate_limit, :delivery_rate_period,
         :upload_max_bytes,
         :delivery_compression,
+        :delivery_base_url,
         :allowed_origins_text,
         { upload_allowed_formats: [] }
       ])

--- a/app/javascript/controllers/delivery_preview_controller.js
+++ b/app/javascript/controllers/delivery_preview_controller.js
@@ -1,11 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Live preview of the delivery path template. As the operator edits the
-// template, render the resulting object keys for a few sample (namespace,
-// locale) pairs supplied via the `samples` value.
+// template, render the resulting full delivery URLs (base URL + object key) for
+// a few sample (namespace, locale) pairs supplied via the `samples` value.
 export default class extends Controller {
   static targets = ["input", "output"]
-  static values = { samples: Array }
+  static values = { samples: Array, baseUrl: String }
 
   connect() {
     this.render()
@@ -15,6 +15,8 @@ export default class extends Controller {
     const template = this.inputTarget.value
     this.outputTarget.innerHTML = ""
 
+    const base = this.baseUrlValue.replace(/\/+$/, "")
+
     for (const s of this.samplesValue) {
       const key = template
         .replaceAll("{project_slug}", s.project_slug)
@@ -23,7 +25,7 @@ export default class extends Controller {
 
       const row = document.createElement("div")
       row.className = "font-mono text-[12px] text-ink-3 truncate"
-      row.textContent = key
+      row.textContent = base ? `${base}/${key}` : key
       this.outputTarget.appendChild(row)
     }
   }

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -5,8 +5,18 @@ class Setting < ApplicationRecord
   CACHE_KEY = "app_setting".freeze
 
   validates :delivery_compression, inclusion: { in: DeliveryCompression::MODES }
+  validates :delivery_base_url,
+    allow_blank: true,
+    format: { with: %r{\Ahttps?://[^\s/]+(/[^\s]*)?\z}i, message: "must start with http:// or https://" }
 
   after_commit :reset_cache
+
+  # Public origin (scheme + host[:port], no trailing slash) shown in delivery
+  # previews so users see the real CDN/ingress URL instead of the request host.
+  # Blank = fall back to the incoming request's base URL.
+  def delivery_base_url=(value)
+    super(value.to_s.strip.chomp("/"))
+  end
 
   def self.current
     Rails.cache.fetch(CACHE_KEY) { first || create! }

--- a/app/views/projects/settings/show.html.erb
+++ b/app/views/projects/settings/show.html.erb
@@ -171,12 +171,16 @@
       <%= loading_button_to "Sync all to storage", project_delivery_sync_path(@project), method: :post, icon: "sync", class: "btn-secondary flex-none",
             data: { turbo_confirm: "Re-materialize every published namespace/locale to #{@project.effective_storage_connection&.name || "local storage"}?" } %>
     </div>
+    <% delivery_base_url = Setting.current.delivery_base_url.presence || request.base_url %>
     <div class="bg-[#0d0d0d] rounded-[9px] px-[18px] py-4 font-mono text-[12.5px] leading-[2] text-[#e4e4e4] overflow-x-auto">
-      <div><span class="text-[#5e5e5e]">GET</span> <%= request.base_url %>/cdn/<span class="text-[#6bd08f]"><%= @project.slug %></span>/{locale}/{namespace}</div>
+      <div><span class="text-[#5e5e5e]">GET</span> <%= delivery_base_url %>/cdn/<span class="text-[#6bd08f]"><%= @project.slug %></span>/{locale}/{namespace}</div>
       <% sample_locale = @project.locales.alphabetically.first&.code || "en" %>
       <% sample_ns = @project.namespaces.alphabetically.first&.name || "common" %>
-      <div><span class="text-[#5e5e5e]">GET</span> <%= request.base_url %>/cdn/<span class="text-[#6bd08f]"><%= @project.slug %></span>/<%= sample_locale %>/<%= sample_ns %></div>
+      <div><span class="text-[#5e5e5e]">GET</span> <%= delivery_base_url %>/cdn/<span class="text-[#6bd08f]"><%= @project.slug %></span>/<%= sample_locale %>/<%= sample_ns %></div>
     </div>
+    <% if Setting.current.delivery_base_url.blank? %>
+      <div class="text-[12px] text-mut mt-[8px]">Showing this request's host. Set a <%= link_to "public delivery URL", workspace_path, class: "text-ink-2 underline underline-offset-2" %> in workspace settings to preview your CDN origin.</div>
+    <% end %>
 
     <%# ---- Storage path template (issue #77): deterministic Active Storage key ---- %>
     <%
@@ -185,7 +189,7 @@
       delivery_samples = ns_names.product(loc_codes).first(3).map { |n, l| { project_slug: @project.slug, namespace: n, locale: l } }
     %>
     <%= form_with model: @project, local: true,
-          data: { controller: "delivery-preview", "delivery-preview-samples-value": delivery_samples.to_json } do |form| %>
+          data: { controller: "delivery-preview", "delivery-preview-samples-value": delivery_samples.to_json, "delivery-preview-base-url-value": delivery_base_url } do |form| %>
       <% if @project.errors[:delivery_path_template].any? %>
         <ul class="mt-4 mb-2 text-[13px] text-danger-ink bg-danger-soft border border-danger-border rounded-[9px] px-4 py-3 list-disc list-inside">
           <% @project.errors[:delivery_path_template].each do |msg| %><li>Path template <%= msg %></li><% end %>

--- a/app/views/workspace/show.html.erb
+++ b/app/views/workspace/show.html.erb
@@ -81,6 +81,28 @@
     <% end %>
   </div>
 
+  <%# ---- Public delivery base URL ---- %>
+  <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
+    <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "link", size: 19, css: "text-ink-3" %>Public delivery URL</div>
+    <div class="text-[13px] text-mut mt-[3px] mb-[18px]">Base URL used to preview delivery endpoints (<span class="font-mono text-[12px]">/cdn/*</span>) in project settings — set this to your public CDN or ingress origin, e.g. <span class="font-mono text-[12px]">https://cdn.example.com</span>. Leave empty to use the domain of the current request.</div>
+
+    <%= form_with model: @setting, url: workspace_path, method: :patch, local: true do |form| %>
+      <% if @setting.errors[:delivery_base_url].any? %>
+        <ul class="mb-4 text-[13px] text-danger-ink bg-danger-soft border border-danger-border rounded-[9px] px-4 py-3 list-disc list-inside">
+          <% @setting.errors[:delivery_base_url].each do |msg| %><li>Base URL <%= msg %></li><% end %>
+        </ul>
+      <% end %>
+      <div class="flex flex-col gap-[7px]">
+        <%= form.label :delivery_base_url, "Base URL", class: "text-[12.5px] font-medium text-ink-2" %>
+        <%= form.text_field :delivery_base_url, placeholder: "https://cdn.example.com",
+              autocomplete: "off", autocapitalize: "none", spellcheck: "false", inputmode: "url", class: "font-mono text-[13px]" %>
+      </div>
+      <div class="flex justify-end mt-[18px]">
+        <%= loading_submit form, "Save changes" %>
+      </div>
+    <% end %>
+  </div>
+
   <%# ---- Delivery compression ---- %>
   <div class="border border-line rounded-[11px] px-[22px] py-5 mb-4">
     <div class="flex items-center gap-[9px] text-[15px] font-semibold text-ink"><%= mi "compress", size: 19, css: "text-ink-3" %>Delivery compression</div>

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,10 @@
 #!/bin/bash -e
 
-# If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+# Create/migrate the database on boot when running the rails server. Gated by
+# RUN_DB_PREPARE (default true) so orchestrators that migrate via a dedicated
+# one-shot Job/init step (e.g. Kubernetes) can set RUN_DB_PREPARE=false and avoid
+# every replica racing to migrate.
+if [ "${RUN_DB_PREPARE:-true}" == "true" ] && [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,16 +22,19 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
+  # Delivery/storage targets are configured at runtime via the UI (StorageConnection).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Assume access is through an SSL-terminating reverse proxy (ingress / load
+  # balancer). Enabled by default; set RAILS_ASSUME_SSL=false to opt out.
+  config.assume_ssl = ENV.fetch("RAILS_ASSUME_SSL", "true") == "true"
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  # Force all access over SSL, use HSTS, and secure cookies. On by default; set
+  # RAILS_FORCE_SSL=false when TLS is not terminated in front of the app.
+  config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "true") == "true"
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Skip http-to-https redirect for the default health check endpoint so probes work.
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -57,17 +60,21 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # Host used by links generated in mailer templates (set APP_HOST=your.domain).
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # Outgoing SMTP server, configured entirely from the environment. When
+  # SMTP_PASSWORD is unset, delivery errors are swallowed so the app still boots.
+  config.action_mailer.raise_delivery_errors = ENV["SMTP_PASSWORD"].present?
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:        ENV.fetch("SMTP_HOST", "smtp.resend.com"),
+    port:           ENV.fetch("SMTP_PORT", 465).to_i,
+    user_name:      ENV.fetch("SMTP_USERNAME", "resend"),
+    password:       ENV["SMTP_PASSWORD"],
+    authentication: :plain,
+    tls:            true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -79,12 +86,13 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # DNS rebinding / Host-header protection. Populate from RAILS_HOSTS (comma
+  # separated, e.g. "app.example.com,.example.com"). A leading "." is expanded to
+  # a subdomain wildcard regexp. Empty = allow all hosts (fine behind a trusted
+  # ingress that already routes by host).
+  if (hosts = ENV.fetch("RAILS_HOSTS", "").split(",").map(&:strip).reject(&:empty?)).any?
+    config.hosts = hosts.map { |h| h.start_with?(".") ? /.*#{Regexp.escape(h)}\z/ : h }
+    # Skip DNS rebinding protection for the default health check endpoint.
+    config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  end
 end

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -7,7 +7,10 @@
 Rails.application.configure do
   enc = config.active_record.encryption
 
-  if Rails.env.local?
+  # `SECRET_KEY_BASE_DUMMY` marks a throwaway boot (e.g. `assets:precompile`
+  # during the Docker build) where no real secrets exist and nothing is actually
+  # encrypted — derive keys there too so the build doesn't need production keys.
+  if Rails.env.local? || ENV["SECRET_KEY_BASE_DUMMY"].present?
     generator = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base, hash_digest_class: OpenSSL::Digest::SHA256)
     enc.primary_key         = ENV["AR_ENCRYPTION_PRIMARY_KEY"]         || generator.generate_key("ar-encryption-primary", 32)
     enc.deterministic_key   = ENV["AR_ENCRYPTION_DETERMINISTIC_KEY"]   || generator.generate_key("ar-encryption-deterministic", 32)

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,22 +6,6 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+# Active Storage keeps app blobs (imports/exports, backups) on local disk.
+# Cloud delivery/storage targets are configured at runtime through the UI
+# (see StorageConnection), not here.

--- a/db/migrate/20260701120000_add_delivery_base_url_to_settings.rb
+++ b/db/migrate/20260701120000_add_delivery_base_url_to_settings.rb
@@ -1,0 +1,5 @@
+class AddDeliveryBaseUrlToSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :settings, :delivery_base_url, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_220653) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -183,6 +183,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_220653) do
   create_table "settings", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "allowed_origins", default: [], null: false, array: true
     t.datetime "created_at", null: false
+    t.string "delivery_base_url", default: "", null: false
     t.string "delivery_compression", default: "gzip", null: false
     t.integer "delivery_rate_limit", default: 300, null: false
     t.integer "delivery_rate_period", default: 60, null: false

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,81 @@
+# Production-shaped, single-node deployment: builds the app image, runs an
+# external Postgres, migrates once, then serves. Two steps to run:
+#   1) cp .env.example .env   && fill SECRET_KEY_BASE, AR_ENCRYPTION_*, BACK_DATABASE_PASSWORD
+#   2) docker compose -f docker-compose.prod.yml up -d
+# Pulls belzkai/language-bridge:0.0.1 from Docker Hub. App on http://localhost:8080
+# (health: /up). To build locally instead, uncomment `build:` below and add --build.
+#
+# NOTE: this is the "Docker" path. For the dev sandbox (Postgres + Mailhog only)
+# use compose.yml instead.
+
+x-app: &app
+  # Uses the published image by default. Uncomment `build` to build locally
+  # instead (the built image is tagged with the same name).
+  # build:
+  #   context: .
+  image: belzkai/language-bridge:0.0.1
+  env_file: .env
+  environment:
+    RAILS_ENV: production
+    # Talk to the bundled Postgres over the compose network.
+    DB_HOST: db
+    DB_PORT: "5432"
+  depends_on:
+    db:
+      condition: service_healthy
+
+services:
+  db:
+    image: postgres:18
+    restart: unless-stopped
+    environment:
+      # Production connects as role "back" (see config/database.yml). Its
+      # password comes from BACK_DATABASE_PASSWORD in your .env.
+      POSTGRES_USER: back
+      POSTGRES_PASSWORD: ${BACK_DATABASE_PASSWORD:?set BACK_DATABASE_PASSWORD in .env}
+      POSTGRES_DB: back_production
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U back -d back_production"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot: creates the 4 Solid databases (primary/cache/queue/cable) and migrates.
+  migrate:
+    <<: *app
+    command: ["./bin/rails", "db:prepare"]
+    environment:
+      RAILS_ENV: production
+      DB_HOST: db
+      DB_PORT: "5432"
+      RUN_DB_PREPARE: "false"
+    restart: "no"
+
+  web:
+    <<: *app
+    command: ["./bin/thrust", "./bin/rails", "server"]
+    environment:
+      RAILS_ENV: production
+      DB_HOST: db
+      DB_PORT: "5432"
+      # Migration handled by the `migrate` service; don't race on boot.
+      RUN_DB_PREPARE: "false"
+      # Run the Solid Queue supervisor inside Puma (single-node = one process).
+      SOLID_QUEUE_IN_PUMA: "true"
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8080:80"
+    restart: unless-stopped
+    # Persist Active Storage blobs (imports/exports, backups) on local disk.
+    volumes:
+      - app-storage:/rails/storage
+
+volumes:
+  pg-data:
+  app-storage:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,75 @@
+# Kubernetes deployment
+
+Provider-neutral plain manifests. Bring your own cluster, ingress controller, and
+**external PostgreSQL** (managed Postgres, or one you run separately). The app is
+12-factor: everything is configured through env vars in `configmap.yaml` +
+`secret.yaml`.
+
+## Two steps
+
+**1. Configure**
+
+```sh
+# Secrets — copy the template, generate values, fill it in
+cp secret.example.yaml secret.yaml
+bin/rails secret              # -> SECRET_KEY_BASE
+bin/rails db:encryption:init  # -> the three AR_ENCRYPTION_* keys
+$EDITOR secret.yaml           # paste values (also BACK_DATABASE_PASSWORD, SMTP, S3)
+
+# Non-secret config — set DB_HOST, APP_HOST/RAILS_HOSTS, storage, image, ...
+$EDITOR configmap.yaml
+```
+
+The manifests point at `belzkai/language-bridge:0.0.1` (published on Docker Hub).
+Change that image tag in `migrate-job.yaml`, `web-deployment.yaml`, and
+`jobs-deployment.yaml` if you publish under a different repo.
+
+**2. Deploy**
+
+```sh
+kubectl apply -f secret.yaml -f configmap.yaml
+kubectl apply -f .        # migrate Job + web + jobs + service (+ ingress/hpa)
+```
+
+The `migrate` Job creates the 4 databases (primary + Solid cache/queue/cable) and
+runs migrations. Web/job pods wait on it via an initContainer, so no replica ever
+races to migrate. Then apply `ingress.example.yaml` (edit host/TLS first).
+
+## What each file is
+
+| File | Purpose |
+|------|---------|
+| `secret.example.yaml` | Template for secret env vars → copy to `secret.yaml` |
+| `configmap.yaml` | Non-secret env vars (DB host, storage, hosts, SMTP) |
+| `migrate-job.yaml` | One-shot `db:prepare` (create DBs + migrate) |
+| `web-deployment.yaml` | Puma + Thruster, `/up` probes, waits for migrations |
+| `web-service.yaml` | ClusterIP for the web pods |
+| `jobs-deployment.yaml` | Solid Queue workers (`bin/jobs`) — optional |
+| `ingress.example.yaml` | Host + TLS termination (edit for your controller) |
+| `hpa.yaml` | Optional CPU autoscaling (needs metrics-server) |
+| `pvc.yaml` | Only for `ACTIVE_STORAGE_SERVICE=local` (prefer S3/GCS) |
+
+## Storage (important for >1 replica)
+
+Active Storage holds app blobs (imports/exports, backups) on local disk at
+`/rails/storage`. The web and jobs pods mount the shared `pvc.yaml` claim there.
+Because that path is per-pod, the claim must be **ReadWriteMany** when more than
+one pod writes to it — use an RWX storage class (NFS, EFS, Filestore, Longhorn).
+If only ReadWriteOnce is available, keep web `replicas: 1` and disable the HPA.
+
+Cloud **delivery/storage targets** (S3/GCS/Azure per project) are configured at
+runtime in the app UI (StorageConnection), not through these manifests.
+
+## Jobs: two shapes
+
+- **Dedicated workers (default here):** `SOLID_QUEUE_IN_PUMA=false` +
+  `jobs-deployment.yaml`. Scale web and jobs independently.
+- **Simplest:** set `SOLID_QUEUE_IN_PUMA=true` in `configmap.yaml` and delete
+  `jobs-deployment.yaml` — web pods run jobs in-process.
+
+## Database
+
+`config/database.yml` connects the production primary as role **`back`** using
+`BACK_DATABASE_PASSWORD`, at `DB_HOST:DB_PORT`. That role needs privileges to
+`CREATE DATABASE` (the Job creates `back_production`, `_cache`, `_queue`,
+`_cable`). Grant `CREATEDB` or run the Job once with a superuser, then downgrade.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,38 @@
+# Non-secret runtime configuration. Edit values, then `kubectl apply -f`.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: language-bridge-config
+  labels:
+    app: language-bridge
+data:
+  RAILS_ENV: "production"
+  RAILS_LOG_LEVEL: "info"
+  PORT: "80"
+  WEB_CONCURRENCY: "2"
+  RAILS_MAX_THREADS: "3"
+
+  # HTTP / TLS / host — TLS terminated at the ingress.
+  APP_HOST: "app.example.com"
+  RAILS_HOSTS: "app.example.com"
+  RAILS_ASSUME_SSL: "true"
+  RAILS_FORCE_SSL: "true"
+
+  # External Postgres. The app uses 4 DBs on this host (primary + Solid
+  # cache/queue/cable); the migrate Job creates them. Password is a Secret.
+  DB_HOST: "your-postgres-host"
+  DB_PORT: "5432"
+
+  # Jobs run in a dedicated Deployment (jobs-deployment.yaml), so keep them out
+  # of Puma here. Set to "true" and delete jobs-deployment.yaml for the simple
+  # single-Deployment setup.
+  SOLID_QUEUE_IN_PUMA: "false"
+  JOB_CONCURRENCY: "1"
+
+  # Mailer
+  SMTP_HOST: "smtp.resend.com"
+  SMTP_PORT: "465"
+  SMTP_USERNAME: "resend"
+  MAIL_FROM: "Language Bridge <onboarding@resend.dev>"
+
+  MT_PROVIDER: "stub"

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,22 @@
+# Optional autoscaler for the web Deployment. Requires metrics-server in the
+# cluster. Delete if you scale manually.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: language-bridge-web
+  labels:
+    app: language-bridge
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: language-bridge-web
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/ingress.example.yaml
+++ b/k8s/ingress.example.yaml
@@ -1,0 +1,31 @@
+# Ingress example. Provider-neutral; adjust ingressClassName and annotations to
+# your controller (nginx, traefik, GKE, ALB, ...). TLS is terminated here, which
+# is why the app runs with RAILS_ASSUME_SSL/RAILS_FORCE_SSL=true.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: language-bridge
+  labels:
+    app: language-bridge
+  annotations:
+    # cert-manager (if installed) — auto-provision a Let's Encrypt cert:
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # nginx — allow large translation import/backup uploads:
+    # nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+spec:
+  ingressClassName: nginx # <-- your ingress controller
+  tls:
+    - hosts:
+        - app.example.com # <-- your host (match APP_HOST / RAILS_HOSTS)
+      secretName: language-bridge-tls
+  rules:
+    - host: app.example.com # <-- your host
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: language-bridge-web
+                port:
+                  name: http

--- a/k8s/jobs-deployment.yaml
+++ b/k8s/jobs-deployment.yaml
@@ -1,0 +1,74 @@
+# Dedicated Solid Queue worker Deployment (bin/jobs). Keep this when
+# SOLID_QUEUE_IN_PUMA=false in the ConfigMap.
+#
+# Simpler alternative: delete this file and set SOLID_QUEUE_IN_PUMA=true so the
+# web pods run jobs in-process. Do that only for small/single deployments.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: language-bridge-jobs
+  labels:
+    app: language-bridge
+    component: jobs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: language-bridge
+      component: jobs
+  template:
+    metadata:
+      labels:
+        app: language-bridge
+        component: jobs
+    spec:
+      initContainers:
+        - name: wait-for-migrations
+          image: belzkai/language-bridge:0.0.1
+          command:
+            - sh
+            - -c
+            - |
+              until ./bin/rails db:abort_if_pending_migrations >/dev/null 2>&1; do
+                echo "waiting for database migrations..."; sleep 3;
+              done
+          envFrom:
+            - configMapRef:
+                name: language-bridge-config
+            - secretRef:
+                name: language-bridge-secrets
+      containers:
+        - name: jobs
+          image: belzkai/language-bridge:0.0.1
+          command: ["./bin/jobs"]
+          envFrom:
+            - configMapRef:
+                name: language-bridge-config
+            - secretRef:
+                name: language-bridge-secrets
+          env:
+            - name: RUN_DB_PREPARE
+              value: "false"
+            - name: SOLID_QUEUE_IN_PUMA
+              value: "false"
+          volumeMounts:
+            # Active Storage blobs (backups written by jobs). Shared with web.
+            - name: storage
+              mountPath: /rails/storage
+          # No HTTP port. Liveness = process is up (Solid Queue supervisor).
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pgrep -f solid_queue || pgrep -f bin/jobs"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: language-bridge-storage

--- a/k8s/migrate-job.yaml
+++ b/k8s/migrate-job.yaml
@@ -1,0 +1,42 @@
+# One-shot migration Job: creates the 4 Solid databases and runs migrations.
+# Web/job pods wait for this via an initContainer, so no replica ever races to
+# migrate. Re-runs safely on each deploy (db:prepare is idempotent).
+#
+# ttlSecondsAfterFinished cleans the Job up automatically. Bump the name (or use
+# `kubectl delete job` first) if you re-apply before it's collected.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: language-bridge-migrate
+  labels:
+    app: language-bridge
+    component: migrate
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: language-bridge
+        component: migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: belzkai/language-bridge:0.0.1
+          command: ["./bin/rails", "db:prepare"]
+          envFrom:
+            - configMapRef:
+                name: language-bridge-config
+            - secretRef:
+                name: language-bridge-secrets
+          env:
+            - name: RUN_DB_PREPARE
+              value: "false"
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,22 @@
+# Active Storage keeps app blobs (imports/exports, backups) on local disk at
+# /rails/storage. That path is per-pod, so it MUST be shared (ReadWriteMany) when
+# more than one pod writes to it. The web and jobs Deployments mount this claim.
+#
+# Many cloud block-storage classes are ReadWriteOnce only — if RWX is
+# unavailable, use ReadWriteOnce and keep web replicas at 1 (and disable the HPA).
+# For true horizontal scale, back /rails/storage with an RWX class (NFS, EFS,
+# Filestore, Longhorn, ...). Cloud delivery targets are separate and configured
+# in the UI (StorageConnection).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: language-bridge-storage
+  labels:
+    app: language-bridge
+spec:
+  accessModes:
+    - ReadWriteMany # use ReadWriteOnce + replicas:1 if RWX is unavailable
+  resources:
+    requests:
+      storage: 10Gi
+  # storageClassName: nfs   # <-- an RWX-capable class

--- a/k8s/secret.example.yaml
+++ b/k8s/secret.example.yaml
@@ -1,0 +1,29 @@
+# Secret template. DO NOT commit real values. Copy to secret.yaml, fill in, then
+#   kubectl apply -f secret.yaml
+# Generate values with:
+#   bin/rails secret                 # SECRET_KEY_BASE
+#   bin/rails db:encryption:init     # the three AR_ENCRYPTION_* keys
+#
+# Using stringData so you paste plain text (Kubernetes base64-encodes it for you).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: language-bridge-secrets
+  labels:
+    app: language-bridge
+type: Opaque
+stringData:
+  # Core secret — provide SECRET_KEY_BASE (preferred) or RAILS_MASTER_KEY.
+  SECRET_KEY_BASE: "REPLACE_ME"
+  # RAILS_MASTER_KEY: "REPLACE_ME"
+
+  # ActiveRecord encryption keys (required in production).
+  AR_ENCRYPTION_PRIMARY_KEY: "REPLACE_ME"
+  AR_ENCRYPTION_DETERMINISTIC_KEY: "REPLACE_ME"
+  AR_ENCRYPTION_KEY_DERIVATION_SALT: "REPLACE_ME"
+
+  # Production Postgres password for role "back".
+  BACK_DATABASE_PASSWORD: "REPLACE_ME"
+
+  # SMTP
+  SMTP_PASSWORD: "REPLACE_ME"

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -1,0 +1,93 @@
+# Web (Puma + Thruster) Deployment. Stateless — scale replicas freely as long as
+# ACTIVE_STORAGE_SERVICE points at object storage (s3/gcs), not local disk.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: language-bridge-web
+  labels:
+    app: language-bridge
+    component: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: language-bridge
+      component: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: language-bridge
+        component: web
+    spec:
+      # Block startup until the migrate Job has created + migrated the DB. This
+      # exits non-zero while DBs are missing or migrations pending, so it waits.
+      initContainers:
+        - name: wait-for-migrations
+          image: belzkai/language-bridge:0.0.1
+          command:
+            - sh
+            - -c
+            - |
+              until ./bin/rails db:abort_if_pending_migrations >/dev/null 2>&1; do
+                echo "waiting for database migrations..."; sleep 3;
+              done
+          envFrom:
+            - configMapRef:
+                name: language-bridge-config
+            - secretRef:
+                name: language-bridge-secrets
+      containers:
+        - name: web
+          image: belzkai/language-bridge:0.0.1
+          command: ["./bin/thrust", "./bin/rails", "server"]
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: language-bridge-config
+            - secretRef:
+                name: language-bridge-secrets
+          env:
+            # Migration is handled by the Job/initContainer, never on boot.
+            - name: RUN_DB_PREPARE
+              value: "false"
+          volumeMounts:
+            # Active Storage blobs (imports/exports, backups). Shared across pods.
+            - name: storage
+              mountPath: /rails/storage
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30 # up to ~150s to boot before giving up
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: language-bridge-storage

--- a/k8s/web-service.yaml
+++ b/k8s/web-service.yaml
@@ -1,0 +1,17 @@
+# Stable in-cluster endpoint for the web pods. The ingress targets this Service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: language-bridge-web
+  labels:
+    app: language-bridge
+    component: web
+spec:
+  type: ClusterIP
+  selector:
+    app: language-bridge
+    component: web
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## Summary
Makes the app deployable as a portable, 12-factor Docker image (config via ENV, external Postgres) and adds a configurable public delivery base URL.

## Deploy (docker & kubernetes)
- **12-factor config** via ENV: SSL (`RAILS_ASSUME_SSL`/`RAILS_FORCE_SSL`), host authorization (`RAILS_HOSTS`), mailer host (`APP_HOST`) + SMTP
- `RUN_DB_PREPARE` gate in `bin/docker-entrypoint` so k8s replicas don't race migrations (dedicated migrate Job handles it)
- `docker-compose.prod.yml` — single-node path (db + one-shot migrate + web), pulls the published image
- `k8s/` — provider-neutral plain manifests: configmap, secret template, migrate Job, web Deployment/Service (with `/up` probes + wait-for-migrations initContainer), jobs Deployment, ingress, HPA, PVC + README
- `Dockerfile` `HEALTHCHECK` on `/up`
- `.github/workflows/docker-publish.yml` — build + push image on `v*` tags
- Image published as `belzkai/language-bridge:0.0.1`

## Fix
- `fix(build)`: derive AR encryption keys during the dummy-secret `assets:precompile` boot so the docker build doesn't require production `AR_ENCRYPTION_*` keys (runtime still requires them)

## Feature — configurable delivery base URL
- New global `delivery_base_url` setting, editable in **workspace settings**
- Project **public delivery** section previews full CDN endpoints and storage-template paths using it (falls back to request host when blank)

## Verification
- `kubectl apply --dry-run=client -f k8s/` OK; `docker compose config` OK
- `SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production` boot no longer raises
- `bin/rails test` (PARALLEL_WORKERS=1): workspace + project settings controllers pass
- Image built & pushed to Docker Hub

Note: Active Storage stays local disk (cloud delivery targets are configured in the UI via StorageConnection).