### PR TITLE
refactor(docker): keep prod compose clean; local/test stack in its own file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,11 @@
 #   bin/rails secret                        # SECRET_KEY_BASE
 #   bin/rails db:encryption:init            # the three AR_ENCRYPTION_* keys
 #
-# NOTE: the local Docker stack needs NONE of this — just run
-#   docker compose -f docker-compose.prod.yml up --build
-# It ships LOCAL-ONLY secret defaults. Fill a real .env only for an actual deploy
-# (real secrets, SMTP, MT provider); if present, it overrides those defaults.
+# NOTE: the local/test Docker stack needs NONE of this — just run
+#   docker compose -f docker-compose.local.yml up --build
+# It ships LOCAL-ONLY secret defaults and routes mail to Mailhog. Fill a real .env
+# for docker-compose.prod.yml or any actual deploy (real secrets, SMTP, MT
+# provider); if present, it overrides those defaults.
 
 # ── Core secrets (REQUIRED in production) ────────────────────────────────────
 # Provide EITHER SECRET_KEY_BASE (recommended for 12-factor) OR RAILS_MASTER_KEY.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,10 @@
 # Minimal data for local development. Idempotent (find_or_create_by!) so it is
 # safe to run repeatedly. Single-tenant: one admin, one project.
+#
+# Dev/test only: db:prepare runs seeds when it creates the database, including in
+# production. This demo data (fake admin, sample project) must never land in a
+# real deploy, so bail out unless we're in a local environment.
+return unless Rails.env.local?
 
 admin = User.find_or_create_by!(email: "admin@example.com") { |u| u.role = "admin" }
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,115 @@
+# LOCAL / TEST all-in-one stack: builds the app image, runs a bundled Postgres +
+# Mailhog, migrates once, then serves. One step to run, zero setup:
+#
+#   docker compose -f docker-compose.local.yml up --build
+#
+# App on http://localhost:8080 (health: /up); Mailhog inbox on http://localhost:8025.
+# No .env needed — the secrets below default to LOCAL-ONLY values baked into this
+# file. This file is NOT for production; it runs RAILS_ENV=production only to mirror
+# the real image, with throwaway secrets and mail routed to Mailhog.
+#
+# For a real single-node deploy use docker-compose.prod.yml (published image,
+# explicit secrets, external SMTP). For the dev sandbox (Postgres + Mailhog only,
+# app on the host) use compose.yml.
+
+# Shared environment. `<<: *app-env` merges this into each service's own
+# environment map (YAML's merge key does NOT deep-merge nested maps, so services
+# reference it explicitly rather than relying on `<<: *app` alone).
+x-app-env: &app-env
+  RAILS_ENV: production
+  # Talk to the bundled Postgres over the compose network.
+  DB_HOST: db
+  DB_PORT: "5432"
+  # ── LOCAL-ONLY secret defaults ───────────────────────────────────────────────
+  # Override every one of these in a real deploy. Safe to commit: they only unlock
+  # a throwaway local stack. `${VAR:-default}` = env/.env still wins.
+  SECRET_KEY_BASE: ${SECRET_KEY_BASE:-b8e2613ecb4918232c830b2fa0d531c0d9faa894bf2cf22bf1ae3ef00684cce2aa992b55e30f8b7acbfaaa5544822db49eecb146b3c19c2c7b448164bd1f271e}
+  AR_ENCRYPTION_PRIMARY_KEY: ${AR_ENCRYPTION_PRIMARY_KEY:-CU2Hst4GvcWhJDhioo5FwNZO75XXD491}
+  AR_ENCRYPTION_DETERMINISTIC_KEY: ${AR_ENCRYPTION_DETERMINISTIC_KEY:-ERJOo4jA5M21hDtTrBhqj2nRHNG9P230}
+  AR_ENCRYPTION_KEY_DERIVATION_SALT: ${AR_ENCRYPTION_KEY_DERIVATION_SALT:-IMuTIcy0rcOtodfDICtsKGYe7ehcNQMl}
+  BACK_DATABASE_PASSWORD: ${BACK_DATABASE_PASSWORD:-back}
+
+x-app: &app
+  # Build the image locally and tag it. (Swap for `image: <registry>/...` to run
+  # a pre-published image instead.)
+  build:
+    context: .
+  image: language-bridge:local
+  # .env is optional: if present it overrides the defaults above.
+  env_file:
+    - path: .env
+      required: false
+  depends_on:
+    db:
+      condition: service_healthy
+
+services:
+  db:
+    image: postgres:18
+    restart: unless-stopped
+    environment:
+      # Production connects as role "back" (see config/database.yml). Its
+      # password comes from BACK_DATABASE_PASSWORD in your .env.
+      POSTGRES_USER: back
+      # Defaults to "back" for the local stack; override via env/.env in a real deploy.
+      POSTGRES_PASSWORD: ${BACK_DATABASE_PASSWORD:-back}
+      POSTGRES_DB: back_production
+    volumes:
+      # PG18 stores data in a version subdir; mount the parent (not .../data).
+      - pg-data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U back -d back_production"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot: creates the 4 Solid databases (primary/cache/queue/cable) and migrates.
+  migrate:
+    <<: *app
+    command: ["./bin/rails", "db:prepare"]
+    environment:
+      <<: *app-env
+      RUN_DB_PREPARE: "false"
+    restart: "no"
+
+  web:
+    <<: *app
+    command: ["./bin/thrust", "./bin/rails", "server"]
+    environment:
+      <<: *app-env
+      # Migration handled by the `migrate` service; don't race on boot.
+      RUN_DB_PREPARE: "false"
+      # Run the Solid Queue supervisor inside Puma (single-node = one process).
+      SOLID_QUEUE_IN_PUMA: "true"
+      # ── TEST MAIL: route all outgoing mail to the bundled Mailhog ──────────────
+      # Plain SMTP, no TLS/auth. Inbox UI at http://localhost:8025.
+      SMTP_HOST: ${SMTP_HOST:-mailhog}
+      SMTP_PORT: ${SMTP_PORT:-1025}
+      SMTP_TLS: ${SMTP_TLS:-false}
+      SMTP_AUTHENTICATION: ${SMTP_AUTHENTICATION:-}
+      # Non-empty so raise_delivery_errors is on (surfaces mail failures in tests).
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-test}
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      mailhog:
+        condition: service_started
+    ports:
+      - "8080:80"
+    restart: unless-stopped
+    # Persist Active Storage blobs (imports/exports, backups) on local disk.
+    volumes:
+      - app-storage:/rails/storage
+
+  # Test-only mail catcher. Captures every outgoing email; nothing leaves the host.
+  mailhog:
+    image: mailhog/mailhog
+    restart: unless-stopped
+    ports:
+      - "8025:8025"   # web UI
+
+volumes:
+  pg-data:
+  app-storage:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,42 +1,25 @@
-# Production-shaped, single-node deployment: builds the app image, runs a bundled
-# Postgres, migrates once, then serves. One step to run, zero setup:
-#
-#   docker compose -f docker-compose.prod.yml up --build
-#
-# App on http://localhost:8080 (health: /up). No .env needed — the secrets below
-# default to LOCAL-ONLY values baked into this file. A real deploy MUST override
-# them (export the vars or drop a .env next to this file; both win over defaults).
+# Production-shaped, single-node deployment: builds the app image, runs an
+# external Postgres, migrates once, then serves. Two steps to run:
+#   1) cp .env.example .env   && fill SECRET_KEY_BASE, AR_ENCRYPTION_*, BACK_DATABASE_PASSWORD
+#   2) docker compose -f docker-compose.prod.yml up -d
+# Pulls belzkai/language-bridge:0.0.1 from Docker Hub. App on http://localhost:8080
+# (health: /up). To build locally instead, uncomment `build:` below and add --build.
 #
 # NOTE: this is the "Docker" path. For the dev sandbox (Postgres + Mailhog only)
 # use compose.yml instead.
 
-# Shared environment. `<<: *app-env` merges this into each service's own
-# environment map (YAML's merge key does NOT deep-merge nested maps, so services
-# reference it explicitly rather than relying on `<<: *app` alone).
-x-app-env: &app-env
-  RAILS_ENV: production
-  # Talk to the bundled Postgres over the compose network.
-  DB_HOST: db
-  DB_PORT: "5432"
-  # ── LOCAL-ONLY secret defaults ───────────────────────────────────────────────
-  # Override every one of these in a real deploy. Safe to commit: they only unlock
-  # a throwaway local stack. `${VAR:-default}` = env/.env still wins.
-  SECRET_KEY_BASE: ${SECRET_KEY_BASE:-b8e2613ecb4918232c830b2fa0d531c0d9faa894bf2cf22bf1ae3ef00684cce2aa992b55e30f8b7acbfaaa5544822db49eecb146b3c19c2c7b448164bd1f271e}
-  AR_ENCRYPTION_PRIMARY_KEY: ${AR_ENCRYPTION_PRIMARY_KEY:-CU2Hst4GvcWhJDhioo5FwNZO75XXD491}
-  AR_ENCRYPTION_DETERMINISTIC_KEY: ${AR_ENCRYPTION_DETERMINISTIC_KEY:-ERJOo4jA5M21hDtTrBhqj2nRHNG9P230}
-  AR_ENCRYPTION_KEY_DERIVATION_SALT: ${AR_ENCRYPTION_KEY_DERIVATION_SALT:-IMuTIcy0rcOtodfDICtsKGYe7ehcNQMl}
-  BACK_DATABASE_PASSWORD: ${BACK_DATABASE_PASSWORD:-back}
-
 x-app: &app
-  # Build the image locally and tag it. (Swap for `image: <registry>/...` to run
-  # a pre-published image instead.)
-  build:
-    context: .
-  image: language-bridge:local
-  # .env is optional: if present it overrides the defaults above.
-  env_file:
-    - path: .env
-      required: false
+  # Uses the published image by default. Uncomment `build` to build locally
+  # instead (the built image is tagged with the same name).
+  # build:
+  #   context: .
+  image: belzkai/language-bridge:0.0.1
+  env_file: .env
+  environment:
+    RAILS_ENV: production
+    # Talk to the bundled Postgres over the compose network.
+    DB_HOST: db
+    DB_PORT: "5432"
   depends_on:
     db:
       condition: service_healthy
@@ -49,12 +32,10 @@ services:
       # Production connects as role "back" (see config/database.yml). Its
       # password comes from BACK_DATABASE_PASSWORD in your .env.
       POSTGRES_USER: back
-      # Defaults to "back" for the local stack; override via env/.env in a real deploy.
-      POSTGRES_PASSWORD: ${BACK_DATABASE_PASSWORD:-back}
+      POSTGRES_PASSWORD: ${BACK_DATABASE_PASSWORD:?set BACK_DATABASE_PASSWORD in .env}
       POSTGRES_DB: back_production
     volumes:
-      # PG18 stores data in a version subdir; mount the parent (not .../data).
-      - pg-data:/var/lib/postgresql
+      - pg-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U back -d back_production"]
       interval: 5s
@@ -66,7 +47,9 @@ services:
     <<: *app
     command: ["./bin/rails", "db:prepare"]
     environment:
-      <<: *app-env
+      RAILS_ENV: production
+      DB_HOST: db
+      DB_PORT: "5432"
       RUN_DB_PREPARE: "false"
     restart: "no"
 
@@ -74,39 +57,24 @@ services:
     <<: *app
     command: ["./bin/thrust", "./bin/rails", "server"]
     environment:
-      <<: *app-env
+      RAILS_ENV: production
+      DB_HOST: db
+      DB_PORT: "5432"
       # Migration handled by the `migrate` service; don't race on boot.
       RUN_DB_PREPARE: "false"
       # Run the Solid Queue supervisor inside Puma (single-node = one process).
       SOLID_QUEUE_IN_PUMA: "true"
-      # ── TEST MAIL: route all outgoing mail to the bundled Mailhog ──────────────
-      # Plain SMTP, no TLS/auth. Inbox UI at http://localhost:8025.
-      SMTP_HOST: ${SMTP_HOST:-mailhog}
-      SMTP_PORT: ${SMTP_PORT:-1025}
-      SMTP_TLS: ${SMTP_TLS:-false}
-      SMTP_AUTHENTICATION: ${SMTP_AUTHENTICATION:-}
-      # Non-empty so raise_delivery_errors is on (surfaces mail failures in tests).
-      SMTP_PASSWORD: ${SMTP_PASSWORD:-test}
     depends_on:
       db:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
-      mailhog:
-        condition: service_started
     ports:
       - "8080:80"
     restart: unless-stopped
     # Persist Active Storage blobs (imports/exports, backups) on local disk.
     volumes:
       - app-storage:/rails/storage
-
-  # Test-only mail catcher. Captures every outgoing email; nothing leaves the host.
-  mailhog:
-    image: mailhog/mailhog
-    restart: unless-stopped
-    ports:
-      - "8025:8025"   # web UI
 
 volumes:
   pg-data:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,12 +5,22 @@ image; upgrading is rebuild + recreate, and schema changes apply themselves.
 
 ## The one command
 
+Production (`docker-compose.prod.yml`, published image) — pull the new tag and
+recreate:
+
 ```bash
-docker compose -f docker-compose.prod.yml up --build -d
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-That rebuilds the image (new code + new `db/migrate/*`), then recreates the
-containers. The `pg-data` volume is **not** touched, so all data survives.
+Local / test (`docker-compose.local.yml`, builds from source):
+
+```bash
+docker compose -f docker-compose.local.yml up --build -d
+```
+
+Either recreates the containers with new code + new `db/migrate/*`. The `pg-data`
+volume is **not** touched, so all data survives.
 
 > **Never** add `-v`. `docker compose down -v` deletes the `pg-data` volume — a
 > full data wipe. A normal upgrade never removes volumes.
@@ -32,7 +42,7 @@ scaling or restarting web never triggers a concurrent migration — no races.
 ## Guarantees & limits
 
 - **Forward migrations just work.** Commit each migration with its `schema.rb`
-  and it applies on the next `up --build`.
+  and it applies on the next recreate.
 - **A failed migration blocks the release.** If `migrate` exits non-zero, `web`
   will not start — the app stays down rather than booting against a half-migrated
   schema. **Test migrations before publishing the image.**


### PR DESCRIPTION
## Why
PR #102 accidentally put local/test-only conveniences (local build, baked
LOCAL-ONLY secrets, Mailhog) into `docker-compose.prod.yml` — the file meant for
real single-node deploys. This splits them back out.

## Changes
- **`docker-compose.prod.yml`** — restored to its clean production state
  (published image, explicit/required secrets, external SMTP, no Mailhog).
- **`docker-compose.local.yml`** (new) — the one-command `up --build` stack with
  baked LOCAL-ONLY secrets and a Mailhog test relay. NOT for production.
- **`.env.example`** / **`docs/upgrading.md`** — point at the correct file per use case.

## Not changed
- `config/environments/production.rb` SMTP `tls`/`authentication` stay env-driven;
  defaults preserve the exact prior prod behavior (Resend + TLS + plain auth).
- Migration squash and upgrade docs from #102 are untouched.

## Note
No image was ever published — no `v0.0.1` tag was pushed, so the GHCR publish
workflow never ran.