### PR TITLE
feat(db): make production database name and user env-driven

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -91,6 +91,6 @@ test:
 production:
   primary:
     <<: *default
-    database: back_production
-    username: back
+    database: <%= ENV.fetch("DB_NAME", "language_bridge_production") %>
+    username: <%= ENV.fetch("DB_USERNAME", "language_bridge_admin") %>
     password: <%= ENV["BACK_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
## Antes → Depois

**Antes:** `config/database.yml` (production) com `database: back_production` e `username: back` hardcoded.

**Depois:** ambos vêm de env var com defaults sensatos:
```yaml
production:
  primary:
    <<: *default
    database: <%= ENV.fetch("DB_NAME", "language_bridge_production") %>
    username: <%= ENV.fetch("DB_USERNAME", "language_bridge_admin") %>
    password: <%= ENV["BACK_DATABASE_PASSWORD"] %>
```

## Por quê
Destrava o deploy em k8s, que roda com o role real `language_bridge_admin` e o banco `language_bridge_production` — sem hardcode (12-factor). O ConfigMap sobrescreve `DB_NAME`/`DB_USERNAME`.

## Detalhes
- Senha continua em `BACK_DATABASE_PASSWORD` — **não renomeada** pra não invalidar o SealedSecret existente.
- Dev/test intactos (já usavam `DB_USERNAME`/`DB_PASSWORD` no bloco default).
- Solid cache/queue/cable seguem no primary (consolidação da #110) — sem bancos separados.

## Verificação (Postgres 18 limpo)
- `DB_NAME=language_bridge_production DB_USERNAME=language_bridge_admin RAILS_ENV=production bin/rails db:prepare` → cria/migra o banco com o user certo ✅
- `select current_database(), current_user` → `language_bridge_production` / `language_bridge_admin`; `select 1` conecta ✅
- Test suite: 407 runs, 0 failures ✅

## Deploy
Imagem `belzkai/language-bridge:0.0.3` publicada com esta mudança. O repo de manifests seta `DB_USERNAME`/`DB_NAME` no ConfigMap e bumpa a imagem — tratado do outro lado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)