### PR TITLE
fix(db): default DB_NAME to language_bridge to match provisioned database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -91,6 +91,6 @@ test:
 production:
   primary:
     <<: *default
-    database: <%= ENV.fetch("DB_NAME", "language_bridge_production") %>
+    database: <%= ENV.fetch("DB_NAME", "language_bridge") %>
     username: <%= ENV.fetch("DB_USERNAME", "language_bridge_admin") %>
     password: <%= ENV["BACK_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
## Problema

Pós #111, o default de `DB_NAME` ficou `language_bridge_production`. Mas o banco real no cluster Aurora compartilhado (`general-pgsql`, `10.0.2.60`) se chama **`language_bridge`** — `language_bridge_production` **não existe**.

Resultado no k8s: pod em **CrashLoopBackOff**.
```
PG::ConnectionBad: FATAL: database "language_bridge_production" does not exist
PG::InsufficientPrivilege: ERROR: permission denied to create database
```
`db:prepare` mira um banco inexistente → tenta criar → role `language_bridge_admin` sem CREATEDB → exit 1.

## Fix

Default de `DB_NAME` → `language_bridge` (nome real). ConfigMap ainda pode sobrescrever.

```yaml
database: <%= ENV.fetch("DB_NAME", "language_bridge") %>
```

## Verificação (via read-only)
- `pg_database` no cluster `10.0.2.60`: existe `language_bridge` (owner `postgres`); `language_bridge_production` ausente ✅
- Pods (`k8s`): imagem `belzkai/language-bridge:0.0.3`, CrashLoopBackOff com o erro acima ✅

## Deploy
Alinhar o ConfigMap `vturb-language-bridge-config` pra `DB_NAME=language_bridge` (ou remover o override e usar o default). Depois `rollout restart`.

⚠️ Cluster é Aurora **16.11**; app usa `uuidv7()` (nativo só no PG18). Se o banco `language_bridge` estiver vazio, `db:prepare` pode falhar no `uuidv7()` — confirmar que já tem schema ou função/extensão custom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)